### PR TITLE
Fixes issue in constructor in SklearnModel which calls the super-cons…

### DIFF
--- a/src/models/sklearn_models.py
+++ b/src/models/sklearn_models.py
@@ -52,9 +52,7 @@ class SklearnModel(Model):
         """
 
         super().__init__(model, model_dir, **kwargs)
-        self.model = model
         self.mode = mode
-        self.model_dir = model_dir
         self.model_type = 'sklearn'
 
     def fit(self, dataset: Dataset) -> None:


### PR DESCRIPTION
When using cross validation on an SKLearnModel I get this:

```
Exception ignored in: <function Model.__del__ at 0x28d925ee0>
Traceback (most recent call last):
  File "/Users/cwerner/um/src/DeepTB/DeepMol/src/models/models.py", line 50, in __del__
    shutil.rmtree(self.model_dir)
  File "/Users/cwerner/miniforge3/envs/deepmolm1/lib/python3.8/shutil.py", line 709, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/Users/cwerner/miniforge3/envs/deepmolm1/lib/python3.8/shutil.py", line 707, in rmtree
    orig_st = os.lstat(path)
TypeError: lstat: path should be string, bytes or os.PathLike, not NoneType
```

It is caused by the constructor in SklearnModel which calls the super-constructor, then sets the model dir:
```
self.model_dir = model_dir

```
but the model_dir has been set by the super-constructor. If the parameter value model_dir is None, then the super-constructor - the Model __init__ - sets self.model_dir  to a temp directory. Then the SklearnModel overrides it with None.
Hence the assignment is not needed, and causes a reset of the of the value to boot.

The fix is to simply remove this line from the SklearnModel constructor and let the superclass set it.
I also removed self.model = model, since, while it doesn't cause an error is also unnecessary and may result in future bugs.