### PR TITLE
Bugs/tuple error

### DIFF
--- a/src/models/sklearn_models.py
+++ b/src/models/sklearn_models.py
@@ -145,12 +145,12 @@ class SklearnModel(Model):
             dummy_model.fit(train_ds)
 
             print('Train Score: ')
-            train_score = dummy_model.evaluate(train_ds, metric)
+            train_score = dummy_model.evaluate(train_ds, metric)[0]
             train_scores.append(train_score[metric.name])
             avg_train_score += train_score[metric.name]
 
             print('Test Score: ')
-            test_score = dummy_model.evaluate(test_ds, metric)
+            test_score = dummy_model.evaluate(test_ds, metric)[0]
             test_scores.append(test_score[metric.name])
             avg_test_score += test_score[metric.name]
 

--- a/src/models/sklearn_models.py
+++ b/src/models/sklearn_models.py
@@ -52,9 +52,7 @@ class SklearnModel(Model):
         """
 
         super().__init__(model, model_dir, **kwargs)
-        self.model = model
         self.mode = mode
-        self.model_dir = model_dir
         self.model_type = 'sklearn'
 
     def fit(self, dataset: Dataset) -> None:

--- a/src/parameter_optimization/hyperparameter_optimization.py
+++ b/src/parameter_optimization/hyperparameter_optimization.py
@@ -252,7 +252,7 @@ class HyperparameterOptimizerValidation(HyperparameterOptimizer):
                 except Exception as e:
                     print(e)
 
-                multitask_scores = model.evaluate(valid_dataset, [metric])
+                multitask_scores = model.evaluate(valid_dataset, [metric])[0]
                 valid_score = multitask_scores[metric.name]
                 hp_str = _convert_hyperparam_dict_to_filename(hyper_params)
                 all_scores[hp_str] = valid_score
@@ -278,7 +278,7 @@ class HyperparameterOptimizerValidation(HyperparameterOptimizer):
             best_model, best_hyperparams = model, hyperparameter_tuple
             return best_model, best_hyperparams, all_scores
 
-        multitask_scores = best_model.evaluate(train_dataset, [metric])
+        multitask_scores = best_model.evaluate(train_dataset, [metric])[0]
         train_score = multitask_scores[metric.name]
         print("Best hyperparameters: %s" % str(best_hyperparams))
         print("train_score: %f" % train_score)


### PR DESCRIPTION
Ran into this type error when using cross_validate
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [12], in <cell line: 2>()
      1 #cross validation
----> 2 model.cross_validate(dataset, Metric(roc_auc_score), folds=3)

File ~/um/src/DeepTB/DeepMol/src/models/sklearn_models.py:149, in SklearnModel.cross_validate(self, dataset, metric, folds)
    147 print('Train Score: ')
    148 train_score = dummy_model.evaluate(train_ds, metric)
--> 149 train_scores.append(train_score[metric.name])
    150 avg_train_score += train_score[metric.name]
    152 print('Test Score: ')

TypeError: tuple indices must be integers or slices, not str
```
Cause: 
The change for "[FIX] PEP8 format" on 25/02/2022 added the "None" below to the return value in evaluator.evaluator.Evaluator.compute_model_performance so that both return types would be tuples. 

```
if not per_task_metrics:
    return multitask_scores, None
else:
    return multitask_scores, all_task_scores

```

Unfortunately, the method models.sklearn_models.SklearnModel.cross_validate was still expecting it to be a single dict instead of a tuple with a dict as the first element.
```
print('Train Score: ')
train_score = dummy_model.evaluate(train_ds, metric)
train_scores.append(train_score[metric.name])
avg_train_score += train_score[metric.name]

print('Test Score: ')
test_score = dummy_model.evaluate(test_ds, metric)
test_scores.append(test_score[metric.name])
avg_test_score += test_score[metric.name]
```
train_score[[metric.name](http://metric.name/)] expected a dict but is ends up with a tuple.
Fixed simply be leaving the methods as is, and extracting the first part of the tuple for each of the calls to evaluate() that expect the dict and not the full tuple (caveat: I might have missed some)