### PR TITLE
[HOTFIX] dependencies now solved

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include extra-requirements.txt

--- a/README.md
+++ b/README.md
@@ -50,9 +50,21 @@ operations on molecular data.
 
 Install DeepMol via pip:
 
+If you intend to install all the deepmol modules' dependencies:
+
 ```bash
-pip install deepmol
+pip install deepmol[all]
 ```
+
+Extra modules:
+
+```bash
+pip install deepmol[preprocessing]
+pip install deepmol[machine_learning]
+pip install deepmol[deep_learning]
+```
+
+
 
 <!---
 or

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -1,9 +1,9 @@
-rdkit-pypi==2022.9.3: preprocessing, deep_learning, preprocessing, machine_learning, test
-smilespe==0.0.3: preprocessing, deep_learning, preprocessing, machine_learning, test
-seaborn==0.12.0: preprocessing, deep_learning, preprocessing, machine_learning, test
-joblib==1.1.0: preprocessing, deep_learning, preprocessing, machine_learning, test
-pillow==8.4.0: preprocessing, deep_learning, preprocessing, machine_learning, test
-h5py==3.1.0: preprocessing, deep_learning, preprocessing, machine_learning, test
+rdkit-pypi==2022.9.3: preprocessing, deep_learning, machine_learning, test
+smilespe==0.0.3: preprocessing, deep_learning, machine_learning, test
+seaborn==0.12.0: preprocessing, deep_learning, machine_learning, test
+joblib==1.1.0: preprocessing, deep_learning, machine_learning, test
+pillow==8.4.0: preprocessing, deep_learning, machine_learning, test
+h5py==3.1.0: preprocessing, deep_learning, machine_learning, test
 shap==0.41.0: deep_learning, machine_learning
 gensim==4.2.0: preprocessing
 chembl_structure_pipeline==1.1.0: preprocessing

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -1,0 +1,22 @@
+rdkit-pypi==2022.9.3: preprocessing, deep_learning, preprocessing, machine_learning, test
+smilespe==0.0.3: preprocessing, deep_learning, preprocessing, machine_learning, test
+seaborn==0.12.0: preprocessing, deep_learning, preprocessing, machine_learning, test
+joblib==1.1.0: preprocessing, deep_learning, preprocessing, machine_learning, test
+pillow==8.4.0: preprocessing, deep_learning, preprocessing, machine_learning, test
+h5py==3.1.0: preprocessing, deep_learning, preprocessing, machine_learning, test
+shap==0.41.0: deep_learning, machine_learning
+gensim==4.2.0: preprocessing
+chembl_structure_pipeline==1.1.0: preprocessing
+torch==1.12.1: deep_learning
+torchvision==0.13.1: deep_learning
+torchaudio==0.12.1: deep_learning
+dgl==0.9.1: deep_learning
+deepchem==2.5.0: deep_learning
+tensorflow==2.10.0: deep_learning
+boruta==0.3: preprocessing
+sklearn: machine_learning
+pytest>=7.1.1: test
+pytest-cov>=3.0.0: test
+mypy>=0.942: test
+flake8>=4.0.1: test
+tox>=3.25.0: test

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -6,6 +6,7 @@ pillow==8.4.0: preprocessing, deep_learning, machine_learning, test
 h5py==3.1.0: preprocessing, deep_learning, machine_learning, test
 shap==0.41.0: deep_learning, machine_learning
 gensim==4.2.0: preprocessing
+imblearn: preprocessing
 chembl_structure_pipeline==1.1.0: preprocessing
 torch==1.12.1: deep_learning
 torchvision==0.13.1: deep_learning

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = DeepMol
-version = 0.0.1-beta
+version = 0.0.7-beta
 description = DeepMol: a python-based machine and deep learning framework for drug discovery
 ;long_description = file: README.md
 keywords = machine-learning, deep-learning, cheminformatics, drug-discovery
@@ -11,8 +11,8 @@ platforms = unix, linux, osx, cygwin, win32
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3 :: 3.7
-    Programming Language :: Python :: 3 :: 3.8
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [options]
 package_dir =
@@ -22,39 +22,14 @@ python_requires = >=3.7
 zip_safe = False
 include_package_data = True
 install_requires =
-    rdkit-pypi==2022.3.5
-    smilespe==0.0.3
-    seaborn==0.12.0
-    joblib==1.1.0
-    pillow==8.4.0
-    h5py==3.1.0
-    shap==0.41.0
+    rdkit-pypi==2022.9.3
 
+dependency_links=[
+        'git+https://github.com/samoturk/mol2vec#egg=mol2vec'
+    ]
 
 [options.packages.find]
 where = src
-
-[options.extras_require]
-testing =
-    pytest>=7.1.1
-    pytest-cov>=3.0.0
-    mypy>=0.942
-    flake8>=4.0.1
-    tox>=3.25.0
-preprocessing =
-    gensim==4.2.0
-    mol2vec @ git+https://github.com/samoturk/mol2vec#egg=mol2vec
-    chembl_structure_pipeline==1.1.0
-deep_learning =
-    torch==1.12.1
-    torchvision==0.13.1
-    torchaudio==0.12.1
-    dgl==0.9.1
-    deepchem==2.5.0
-    tensorflow==2.10.0
-machine_learning =
-    boruta==0.3
-
 
 [options.package_data]
 deepmol = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = DeepMol
-version = 0.0.7-beta
+version = 0.0.4-beta
 description = DeepMol: a python-based machine and deep learning framework for drug discovery
 ;long_description = file: README.md
 keywords = machine-learning, deep-learning, cheminformatics, drug-discovery

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,34 @@
 from setuptools import setup
 
+
+def get_extra_requires(path, add_all=True):
+    import re
+    from collections import defaultdict
+
+    with open(path) as fp:
+        extra_deps = defaultdict(set)
+        for k in fp:
+            if k.strip() and not k.startswith('#'):
+                tags = set()
+                if ':' in k:
+                    if "@" in k:
+                        tag, k = k.split("@")
+                        k1, k2, v = k.split(':')
+                        k = tag + " @ " + k1 + ":" + k2
+                        tags.add(tag.strip())
+                    else:
+                        k, v = k.split(':')
+                        tags.add(re.split('[<=>]', k)[0])
+                    tags.update(vv.strip() for vv in v.split(','))
+
+                for t in tags:
+                    extra_deps[t].add(k.strip())
+
+        # add tag `all` at the end
+        if add_all:
+            extra_deps['all'] = set(vv for v in extra_deps.values() for vv in v)
+    return extra_deps
+
+
 if __name__ == "__main__":
-    setup()
+    setup(extras_require=get_extra_requires('extra-requirements.txt'))


### PR DESCRIPTION
This HOTFIX is an attempt to close #9.

I created the file _extra-requirements.txt_ and a parser to read the file following the _package-to-feature_ map in a separate plain text file, then parse it to an inverted map in setup.py.

Also, I added the MANIFEST.in to include the _extra-requirements.txt_ file. This will allow us to include the _extra-requirements.txt_ file while deploying. As pip runs the _setup.py_ file, the requirements file has to be zipped in the tar.gz and whl file.

Available modules:

- deepmol[all] (all modules)
- deepmol[preprocessing]
- deepmol[machine_learning]
- deepmol[deep_learning]