### PR TITLE
General Refactoring of the DeepChem Featurizers

### DIFF
--- a/src/deepmol/compound_featurization/__init__.py
+++ b/src/deepmol/compound_featurization/__init__.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     warnings.warn("Mol2Vec not available. Please install it to use it.")
 
-from .deepchem_featurizers import WeaveFeat, CoulombFeat, CoulombEigFeat, RawFeat, ConvMolFeat, MolGraphConvFeat, \
-    CoulombEigFeat, SmileImageFeat, SmilesSeqFeat
+from .deepchem_featurizers import WeaveFeat, CoulombFeat, CoulombEigFeat, ConvMolFeat, MolGraphConvFeat, \
+    SmileImageFeat, SmilesSeqFeat
 
 from .mixed_descriptors import MixedFeaturizer

--- a/src/deepmol/compound_featurization/_utils.py
+++ b/src/deepmol/compound_featurization/_utils.py
@@ -1,0 +1,88 @@
+from typing import List, Dict
+
+from deepchem.utils import ConformerGenerator
+from rdkit.Chem import Mol
+
+
+def find_maximum_number_atoms(molecules: List[Mol]) -> int:
+    """
+    Finds maximum number of atoms within a set of molecules
+
+    Parameters
+    ----------
+    molecules: List[Mol]
+        List of rdkit mol objects
+
+    Returns
+    -------
+    best: int
+        Maximum number of atoms in a molecule in the list.
+    """
+    best = 0
+    for i, mol in enumerate(molecules):
+        try:
+            atoms = mol.GetNumAtoms()
+            if atoms > best:
+                best = atoms
+        except Exception as e:
+            print('Molecule with index', i, 'was not converted from SMILES into RDKIT object')
+    return best
+
+
+def get_conformers(molecules: List[Mol], generator: ConformerGenerator) -> List[Mol]:
+    """
+    Gets conformers for molecules with a specific generator
+
+    Parameters
+    ----------
+    molecules: List[Mol]
+        List of rdkit mol objects
+    generator: ConformerGenerator
+        DeepChem conformer generator.
+
+    Returns
+    -------
+    new_conformations: List[Mol]
+        List of rdkit mol objects with conformers.
+    """
+    new_conformations = []
+    for i, mol in enumerate(molecules):
+        try:
+            conf = generator.generate_conformers(mol)
+            new_conformations.append(conf)
+        except Exception as e:
+            print('Molecules with index', i, 'was not able to achieve a correct conformation')
+            print('Appending empty list')
+            new_conformations.append([])
+    return new_conformations
+
+
+def get_dictionary_from_smiles(smiles: List[str], max_len: int) -> Dict[str, int]:
+    """
+    Dictionary of character to index mapping
+    Adapted from deepchem.
+
+    Parameters
+    ----------
+    smiles: List[str]
+        List of SMILES string
+    max_len: int
+        Maximum length of SMILES string
+
+    Returns
+    -------
+    dictionary: Dict[str, int]
+        Dictionary of character to index mapping
+    """
+
+    pad_token = "<pad>"
+    out_of_vocab_token = "<unk>"
+
+    char_set = set()
+    for smile in smiles:
+        if len(smile) <= max_len:
+            char_set.update(set(smile))
+
+    unique_char_list = list(char_set) + [pad_token, out_of_vocab_token]
+    dictionary = {letter: idx for idx, letter in enumerate(unique_char_list)}
+    return dictionary

--- a/src/deepmol/compound_featurization/base_featurizer.py
+++ b/src/deepmol/compound_featurization/base_featurizer.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Union, Tuple
 
 import numpy as np
-from rdkit.Chem import MolFromSmiles, rdmolfiles, rdmolops, Mol, MolToSmiles
+from rdkit.Chem import MolFromSmiles, Mol, MolToSmiles
 
 from deepmol.datasets import Dataset
 from deepmol.parallelism.multiprocessing import JoblibMultiprocessing
@@ -19,7 +19,15 @@ class MolecularFeaturizer(ABC):
     Subclasses need to implement the _featurize method for calculating features for a single molecule.
     """
 
-    def __init__(self, n_jobs: int = -1):
+    def __init__(self, n_jobs: int = -1) -> None:
+        """
+        Initializes the featurizer.
+
+        Parameters
+        ----------
+        n_jobs: int
+            The number of jobs to run in parallel in the featurization.
+        """
         self.n_jobs = n_jobs
 
     @staticmethod
@@ -102,7 +110,7 @@ class MolecularFeaturizer(ABC):
                   scaler: BaseScaler = None,
                   path_to_save_scaler: str = None,
                   remove_nans_axis: int = 0
-                  ):
+                  ) -> Dataset:
 
         """
         Calculate features for molecules.
@@ -136,9 +144,10 @@ class MolecularFeaturizer(ABC):
 
         features = np.array(features, dtype=object)
         features = features[~remove_mols_list]
-        # features = np.concatenate(features, axis=0)
 
-        if isinstance(features[0], np.ndarray):
+        if isinstance(features[0], np.ndarray) and len(features[0].shape) == 2:
+            pass
+        else:
             features = np.vstack(features)
         dataset.X = features
 

--- a/src/deepmol/compound_featurization/base_featurizer.py
+++ b/src/deepmol/compound_featurization/base_featurizer.py
@@ -145,7 +145,8 @@ class MolecularFeaturizer(ABC):
         features = np.array(features, dtype=object)
         features = features[~remove_mols_list]
 
-        if isinstance(features[0], np.ndarray) and len(features[0].shape) == 2:
+        if (isinstance(features[0], np.ndarray) and len(features[0].shape) == 2) or not isinstance(features[0],
+                                                                                                   np.ndarray):
             pass
         else:
             features = np.vstack(features)

--- a/src/deepmol/compound_featurization/deepchem_featurizers.py
+++ b/src/deepmol/compound_featurization/deepchem_featurizers.py
@@ -2,7 +2,7 @@ from typing import List, Dict, Any
 
 import numpy as np
 from deepchem.feat import ConvMolFeaturizer, WeaveFeaturizer, MolGraphConvFeaturizer, CoulombMatrix, CoulombMatrixEig, \
-    SmilesToImage, SmilesToSeq, MolGanFeaturizer
+    SmilesToImage, SmilesToSeq, MolGanFeaturizer, GraphMatrix
 from deepchem.feat.graph_data import GraphData
 from deepchem.feat.mol_graphs import ConvMol, WeaveMol
 from deepchem.utils import ConformerGenerator
@@ -147,6 +147,7 @@ class MolGanFeat(MolecularFeaturizer):
     Featurizer for MolGAN de-novo molecular generation model, adapted from deepchem
     (https://deepchem.readthedocs.io/en/latest/api_reference/featurizers.html?highlight=CGCNN#molganfeaturizer).
     It is wrapper for two matrices containing atom and bond type information.
+
     References:
     Nicola De Cao et al. “MolGAN: An implicit generative model for small molecular graphs” (2018),
     https://arxiv.org/abs/1805.11973
@@ -178,7 +179,7 @@ class MolGanFeat(MolecularFeaturizer):
         self.bond_labels = bond_labels
         self.atom_labels = atom_labels
 
-    def _featurize(self, mol: Mol) -> WeaveMol:
+    def _featurize(self, mol: Mol) -> GraphMatrix:
         """
         Featurizes a single molecule.
 
@@ -192,7 +193,7 @@ class MolGanFeat(MolecularFeaturizer):
         feature: WeaveMol
             The WeaveMol features of the molecule.
         """
-        # featurization process using DeepChem WeaveFeaturizer
+        # featurization process using DeepChem MolGanFeat
         feature = MolGanFeaturizer(max_atom_count=self.max_atom_count,
                                    kekulize=self.kekulize,
                                    bond_labels=self.bond_labels,

--- a/src/deepmol/compound_featurization/deepchem_featurizers.py
+++ b/src/deepmol/compound_featurization/deepchem_featurizers.py
@@ -1,111 +1,36 @@
-from typing import List, Union, Dict
+from typing import List, Dict
 
 import numpy as np
 from deepchem.feat import ConvMolFeaturizer, WeaveFeaturizer, MolGraphConvFeaturizer, CoulombMatrix, CoulombMatrixEig, \
-    SmilesToImage, SmilesToSeq, RawFeaturizer
+    SmilesToImage, SmilesToSeq
+from deepchem.feat.graph_data import GraphData
+from deepchem.feat.mol_graphs import ConvMol, WeaveMol
 from deepchem.utils import ConformerGenerator
 from rdkit.Chem import Mol, MolFromSmiles, MolToSmiles
 
 from deepmol.compound_featurization import MolecularFeaturizer
+from deepmol.compound_featurization._utils import get_conformers, get_dictionary_from_smiles
 from deepmol.datasets import Dataset
-
-
-def find_maximum_number_atoms(molecules: List[Mol]):
-    """
-    Finds maximum number of atoms within a set of molecules
-
-    Parameters
-    ----------
-    molecules: List[Mol]
-        List of rdkit mol objects
-
-    Returns
-    -------
-    best: int
-        Maximum number of atoms in a molecule in the list.
-    """
-    best = 0
-    for i, mol in enumerate(molecules):
-        try:
-            atoms = mol.GetNumAtoms()
-            if atoms > best:
-                best = atoms
-        except Exception as e:
-            print('Molecule with index', i, 'was not converted from SMILES into RDKIT object')
-    return best
-
-
-def get_conformers(molecules: List[Mol], generator: ConformerGenerator):
-    """
-    Gets conformers for molecules with a specific generator
-
-    Parameters
-    ----------
-    molecules: List[Mol]
-        List of rdkit mol objects
-    generator: ConformerGenerator
-        DeepChem conformer generator.
-
-    Returns
-    -------
-    new_conformations: List[Mol]
-        List of rdkit mol objects with conformers.
-    """
-    new_conformations = []
-    for i, mol in enumerate(molecules):
-        try:
-            conf = generator.generate_conformers(mol)
-            new_conformations.append(conf)
-        except Exception as e:
-            print('Molecules with index', i, 'was not able to achieve a correct conformation')
-            print('Appending empty list')
-            new_conformations.append([])
-    return new_conformations
-
-
-def get_dictionary_from_smiles(smiles: List[str], max_len: int):
-    """
-    Dictionary of character to index mapping
-    Adapted from deepchem.
-
-    Parameters
-    ----------
-    smiles: List[str]
-        List of SMILES string
-    max_len: int
-        Maximum length of SMILES string
-
-    Returns
-    -------
-    dictionary: Dict[str, int]
-        Dictionary of character to index mapping
-    """
-
-    pad_token = "<pad>"
-    out_of_vocab_token = "<unk>"
-
-    char_set = set()
-    for smile in smiles:
-        if len(smile) <= max_len:
-            char_set.update(set(smile))
-
-    unique_char_list = list(char_set) + [pad_token, out_of_vocab_token]
-    dictionary = {letter: idx for idx, letter in enumerate(unique_char_list)}
-    return dictionary
 
 
 class ConvMolFeat(MolecularFeaturizer):
     """
-    Duvenaud graph convolution, adapted from deepchem.
+    Duvenaud graph convolution, adapted from deepchem
+    (https://deepchem.readthedocs.io/en/latest/api_reference/featurizers.html#convmolfeaturizer).
     Vector of descriptors for each atom in a molecule.
     The featurizers computes that vector of local descriptors.
+
+    References:
+    Duvenaud, David K., et al. "Convolutional networks on graphs for learning molecular fingerprints."
+    Advances in neural information processing systems. 2015.
     """
 
     def __init__(self,
                  master_atom: bool = False,
                  use_chirality: bool = False,
                  atom_properties: List[str] = None,
-                 per_atom_fragmentation: bool = False):
+                 per_atom_fragmentation: bool = False,
+                 **kwargs) -> None:
         """
         Parameters
         ----------
@@ -117,8 +42,10 @@ class ConvMolFeat(MolecularFeaturizer):
             List of atom properties to use as additional atom-level features in the larger molecular feature.
         per_atom_fragmentation: bool
             If True, then multiple "atom-depleted" versions of each molecule will be created.
+        kwargs:
+            Additional arguments for the base class.
         """
-        super().__init__()
+        super().__init__(**kwargs)
         if atom_properties is None:
             atom_properties = []
         self.master_atom = master_atom
@@ -126,53 +53,48 @@ class ConvMolFeat(MolecularFeaturizer):
         self.atom_properties = atom_properties
         self.per_atom_fragmentation = per_atom_fragmentation
 
-    def _featurize(self, mol: Union[Mol, str], log_every_n=1000):
+    def _featurize(self, mol: Mol) -> ConvMol:
         """
         Featurizes a single molecule.
 
         Parameters
         ----------
-        mol: Union[Mol, str]
+        mol: Mol
             Molecule to featurize.
-        log_every_n: int
-            Log every n molecules.
 
         Returns
         -------
-        features: np.ndarray
-            Array of features.
+        feature: ConvMol
+            The ConvMol features of the molecule.
         """
-        # obtain new SMILE's strings
-        if isinstance(mol, str):
-            rdkit_mols = [MolFromSmiles(mol)]
-        elif isinstance(mol, Mol):
-            rdkit_mols = [mol]
-        else:
-            rdkit_mols = None
-
-        # featurization process using DeepChem featurizers
+        # featurization process using DeepChem ConvMolFeaturizer
         feature = ConvMolFeaturizer(
             master_atom=self.master_atom,
             use_chirality=self.use_chirality,
             atom_properties=self.atom_properties,
-            per_atom_fragmentation=self.per_atom_fragmentation).featurize(rdkit_mols)
+            per_atom_fragmentation=self.per_atom_fragmentation).featurize([mol])
 
         assert feature[0].atom_features is not None
-
         return feature[0]
 
 
 class WeaveFeat(MolecularFeaturizer):
     """
-    Weave convolution featurization, adapted from deepchem.
+    Weave convolution featurization, adapted from deepchem
+    (https://deepchem.readthedocs.io/en/latest/api_reference/featurizers.html#weavefeaturizer).
     Require a quadratic matrix of interaction descriptors for each pair of atoms.
+
+    References:
+    Kearnes, Steven, et al. "Molecular graph convolutions: moving beyond fingerprints."
+    Journal of computer-aided molecular design 30.8 (2016): 595-608.
     """
 
     def __init__(self,
                  graph_distance: bool = True,
                  explicit_h: bool = False,
                  use_chirality: bool = False,
-                 max_pair_distance: int = None):
+                 max_pair_distance: int = None,
+                 **kwargs) -> None:
         """
         Parameters
         ----------
@@ -185,43 +107,35 @@ class WeaveFeat(MolecularFeaturizer):
             If True, use chiral information in the featurization.
         max_pair_distance: int
             Maximum graph distance at which pair features are computed.
+        kwargs:
+            Additional arguments for the base class.
         """
-        super().__init__()
+        super().__init__(**kwargs)
         self.graph_distance = graph_distance
         self.explicit_h = explicit_h
         self.use_chirality = use_chirality
         self.max_pair_distance = max_pair_distance
 
-    def _featurize(self, mol: Union[Mol, str], log_every_n=1000):
+    def _featurize(self, mol: Mol) -> WeaveMol:
         """
         Featurizes a single molecule.
 
         Parameters
         ----------
-        mol: Union[Mol, str]
+        mol: Mol
             Molecule to featurize.
-        log_every_n: int
-            Log every n molecules.
 
         Returns
         -------
-        features: np.ndarray
-            Array of features.
+        feature: WeaveMol
+            The WeaveMol features of the molecule.
         """
-        # obtain new SMILE's strings
-        if isinstance(mol, str):
-            rdkit_mols = [MolFromSmiles(mol)]
-        elif isinstance(mol, Mol):
-            rdkit_mols = [mol]
-        else:
-            rdkit_mols = None
-
-        # featurization process using DeepChem featurizers
+        # featurization process using DeepChem WeaveFeaturizer
         feature = WeaveFeaturizer(
             graph_distance=self.graph_distance,
             explicit_H=self.explicit_h,
             use_chirality=self.use_chirality,
-            max_pair_distance=self.max_pair_distance).featurize(rdkit_mols)
+            max_pair_distance=self.max_pair_distance).featurize([mol])
 
         assert feature[0].get_atom_features() is not None
 
@@ -231,13 +145,19 @@ class WeaveFeat(MolecularFeaturizer):
 class MolGraphConvFeat(MolecularFeaturizer):
     """
     Featurizer of general graph convolution networks for molecules.
-    Adapted from deepchem
+    Adapted from deepchem:
+    (https://deepchem.readthedocs.io/en/latest/api_reference/featurizers.html#molgraphconvfeaturizer)
+
+    References:
+    Kearnes, Steven, et al. "Molecular graph convolutions: moving beyond fingerprints."
+    Journal of computer-aided molecular design 30.8 (2016):595-608.
     """
 
     def __init__(self,
                  use_edges: bool = False,
                  use_chirality: bool = False,
-                 use_partial_charge: bool = False):
+                 use_partial_charge: bool = False,
+                 **kwargs) -> None:
         """
         Parameters
         ----------
@@ -247,42 +167,33 @@ class MolGraphConvFeat(MolecularFeaturizer):
             If True, use chirality information.
         use_partial_charge: bool
             If True, use partial charge information.
+        kwargs:
+            Additional arguments for the base class.
         """
-        super().__init__()
+        super().__init__(**kwargs)
         self.use_edges = use_edges
         self.use_chirality = use_chirality
         self.use_partial_charge = use_partial_charge
 
-    def _featurize(self, mol: Union[Mol, str], log_every_n=1000):
+    def _featurize(self, mol: Mol) -> GraphData:
         """
         Featurizes a single molecule.
 
         Parameters
         ----------
-        mol: Union[Mol, str]
+        mol: Mol
             Molecule to featurize.
-        log_every_n: int
-            Log every n molecules.
 
         Returns
         -------
-        features: np.ndarray
-            Array of features.
+        feature: GraphData
+            The GraphData features of the molecule.
         """
-        # obtain new SMILE's strings
-
-        if isinstance(mol, str):
-            rdkit_mols = [MolFromSmiles(mol)]
-        elif isinstance(mol, Mol):
-            rdkit_mols = [mol]
-        else:
-            rdkit_mols = None
-
-        # featurization process using DeepChem featurizers
+        # featurization process using DeepChem MolGraphConvFeaturizer
         feature = MolGraphConvFeaturizer(
             use_edges=self.use_edges,
             use_chirality=self.use_chirality,
-            use_partial_charge=self.use_partial_charge).featurize(rdkit_mols)
+            use_partial_charge=self.use_partial_charge).featurize([mol])
 
         if feature[0].node_features is None:
             raise Exception
@@ -293,7 +204,11 @@ class MolGraphConvFeat(MolecularFeaturizer):
 class CoulombFeat(MolecularFeaturizer):
     """
     Calculate coulomb matrices for molecules.
-    Adapted from deepchem
+    Adapted from deepchem (https://deepchem.readthedocs.io/en/latest/api_reference/featurizers.html#coulombmatrix).
+
+    References:
+    Montavon, Grégoire, et al. "Learning invariant representations of molecules for atomization energy prediction."
+    Advances in neural information processing systems. 2012.
     """
 
     def __init__(self,
@@ -303,7 +218,8 @@ class CoulombFeat(MolecularFeaturizer):
                  upper_tri: bool = False,
                  n_samples: int = 1,
                  max_conformers: int = 1,
-                 seed: int = None):
+                 seed: int = None,
+                 **kwargs) -> None:
         """
         Parameters
         ----------
@@ -321,8 +237,10 @@ class CoulombFeat(MolecularFeaturizer):
             Maximum number of conformers.
         seed: int
             Random seed to use.
+        kwargs:
+            Additional arguments for the base class.
         """
-        super().__init__()
+        super().__init__(**kwargs)
         self.max_atoms = max_atoms
         self.remove_hydrogens = remove_hydrogens
         self.randomize = randomize
@@ -333,34 +251,24 @@ class CoulombFeat(MolecularFeaturizer):
             seed = int(seed)
         self.seed = seed
 
-    def _featurize(self, mol: Union[Mol, str], log_every_n: int = 1000):
+    def _featurize(self, mol: Mol) -> np.ndarray:
         """
         Featurizes a single molecule.
 
         Parameters
         ----------
-        mol: Union[Mol, str]
+        mol: Mol
             Molecule to featurize.
-        log_every_n: int
-            Log every n molecules.
 
         Returns
         -------
-        features: np.ndarray
+        feature: np.ndarray
             Array of features.
         """
-        # obtain new SMILE's strings
-        if isinstance(mol, str):
-            rdkit_mols = [MolFromSmiles(mol)]
-        elif isinstance(mol, Mol):
-            rdkit_mols = [mol]
-        else:
-            rdkit_mols = None
-
         generator = ConformerGenerator(max_conformers=self.max_conformers)
-        new_conformers = get_conformers(rdkit_mols, generator)
+        new_conformers = get_conformers([mol], generator)
 
-        # featurization process using DeepChem featurizers
+        # featurization process using DeepChem CoulombMatrix
         featurizer = CoulombMatrix(
             max_atoms=self.max_atoms,
             remove_hydrogens=self.remove_hydrogens,
@@ -380,7 +288,11 @@ class CoulombFeat(MolecularFeaturizer):
 class CoulombEigFeat(MolecularFeaturizer):
     """
     Calculate the eigen values of Coulomb matrices for molecules.
-    Adapted from deepchem
+    Adapted from deepchem (https://deepchem.readthedocs.io/en/latest/api_reference/featurizers.html#coulombmatrixeig).
+
+    References:
+    Montavon, Grégoire, et al. "Learning invariant representations of molecules for atomization energy prediction."
+    Advances in neural information processing systems. 2012.
     """
 
     def __init__(self,
@@ -389,7 +301,8 @@ class CoulombEigFeat(MolecularFeaturizer):
                  randomize: bool = False,
                  n_samples: int = 1,
                  max_conformers: int = 1,
-                 seed: int = None):
+                 seed: int = None,
+                 **kwargs) -> None:
         """
         Parameters
         ----------
@@ -405,8 +318,10 @@ class CoulombEigFeat(MolecularFeaturizer):
             maximum number of conformers.
         seed: int
             Random seed to use.
+        kwargs:
+            Additional arguments for the base class.
         """
-        super().__init__()
+        super().__init__(**kwargs)
         self.max_atoms = max_atoms
         self.remove_hydrogens = remove_hydrogens
         self.randomize = randomize
@@ -416,38 +331,26 @@ class CoulombEigFeat(MolecularFeaturizer):
         self.seed = seed
         self.max_conformers = max_conformers
 
-    def _featurize(self, mol: Union[Mol, str], log_every_n: int = 1000):
+    def _featurize(self, mol: Mol) -> np.ndarray:
         """
         Featurizes a single molecule.
 
         Parameters
         ----------
-        mol: Union[Mol, str]
+        mol: Mol
             Molecule to featurize.
-        log_every_n: int
-            Log every n molecules.
-
         Returns
         -------
-        features: np.ndarray
+        feature: np.ndarray
             Array of features.
         """
-        # obtain new SMILE's strings
-        if isinstance(mol, str):
-            rdkit_mols = [MolFromSmiles(mol)]
-        elif isinstance(mol, Mol):
-            rdkit_mols = [mol]
-        else:
-            rdkit_mols = None
-
         generator = ConformerGenerator(max_conformers=self.max_conformers)
 
         # TO USE in case to add option for the software to find the parameter max_atoms
         # maximum_number_atoms = find_maximum_number_atoms(new_smiles)
 
-        new_conformers = get_conformers(rdkit_mols, generator)
-        # featurization process using DeepChem featurizers
-        print('Featurizing datapoints')
+        new_conformers = get_conformers([mol], generator)
+        # featurization process using DeepChem CoulombMatrixEig
         featurizer = CoulombMatrixEig(
             max_atoms=self.max_atoms,
             remove_hydrogens=self.remove_hydrogens,
@@ -466,14 +369,20 @@ class CoulombEigFeat(MolecularFeaturizer):
 class SmileImageFeat(MolecularFeaturizer):
     """
     Converts SMILE string to image.
-    Adapted from deepchem
+    Adapted from deepchem (https://deepchem.readthedocs.io/en/latest/api_reference/featurizers.html#smilestoimage).
+
+    References:
+    Goh, Garrett B., et al. "Using rule-based labels for weak supervised learning: a ChemNet for transferable chemical
+    property prediction."
+    Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining. 2018.
     """
 
     def __init__(self,
                  img_size: int = 80,
                  res: float = 0.5,
                  max_len: int = 250,
-                 img_spec: str = "std"):
+                 img_spec: str = "std",
+                 **kwargs) -> None:
         """
         Parameters
         ----------
@@ -485,8 +394,10 @@ class SmileImageFeat(MolecularFeaturizer):
             Maximum allowed length of SMILES string.
         img_spec: str
             Indicates the channel organization of the image tensor.
+        kwargs:
+            Additional arguments for the base class.
         """
-        super().__init__()
+        super().__init__(**kwargs)
         if img_spec not in ["std", "engd"]:
             raise ValueError(
                 "Image mode must be one of the std or engd. {} is not supported".format(img_spec))
@@ -496,33 +407,26 @@ class SmileImageFeat(MolecularFeaturizer):
         self.img_spec = img_spec
         self.embed = int(img_size * res / 2)
 
-    def _featurize(self, mol: Union[Mol, str]):
+    def _featurize(self, mol: Mol) -> np.ndarray:
         """
         Featurizes a single molecule.
 
         Parameters
         ----------
-        mol: Union[Mol, str]
+        mol: Mol
             Molecule to featurize.
 
         Returns
         -------
         features: np.ndarray
-                Array of features.
+            Array of features.
         """
-        if isinstance(mol, str):
-            rdkit_mols = [MolFromSmiles(mol)]
-        elif isinstance(mol, Mol):
-            rdkit_mols = [mol]
-        else:
-            rdkit_mols = None
-
-        # featurization process using DeepChem featurizers
+        # featurization process using DeepChem SmilesToImage
         feats = SmilesToImage(
             img_size=self.img_size,
             max_len=self.max_len,
             res=self.res,
-            img_spec=self.img_spec).featurize(rdkit_mols)
+            img_spec=self.img_spec).featurize([mol])
 
         # identify which rows did not get featurized
         if len(feats[0]) == 0:
@@ -534,13 +438,18 @@ class SmileImageFeat(MolecularFeaturizer):
 class SmilesSeqFeat:
     """
     Takes SMILES strings and turns into a sequence.
-    Adapated from deepchem
+    Adapted from deepchem (https://deepchem.readthedocs.io/en/latest/api_reference/featurizers.html#smilestoseq).
+
+    References:
+    Goh, Garrett B., et al. "Using rule-based labels for weak supervised learning: a ChemNet for transferable chemical
+    property prediction."
+    Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining. 2018.
     """
 
     def __init__(self,
                  char_to_idx: Dict[str, int] = None,
                  max_len: int = 250,
-                 pad_len: int = 10):
+                 pad_len: int = 10) -> None:
         """
         Parameters
         ----------
@@ -551,12 +460,11 @@ class SmilesSeqFeat:
         pad_len: int
             Amount of padding to add on either side of the SMILES seq.
         """
-        super().__init__()
         self.char_to_idx = char_to_idx
         self.max_len = max_len
         self.pad_len = pad_len
 
-    def featurize(self, dataset: Dataset, log_every_n=1000):
+    def featurize(self, dataset: Dataset) -> Dataset:
         """
         Featurizes a single molecule.
 
@@ -564,13 +472,11 @@ class SmilesSeqFeat:
         ----------
         dataset: Dataset
             Dataset to featurize.
-        log_every_n: int
-            Log every n molecules.
 
         Returns
         -------
-        features: np.ndarray
-            Array of features.
+        dataset: Dataset
+            Featurized dataset.
         """
         # Getting the dictionary if it is None
         if self.char_to_idx is None:
@@ -586,7 +492,6 @@ class SmilesSeqFeat:
         dataset.dictionary = self.char_to_idx
 
         # obtain new SMILE's strings
-        print('Converting SMILES to Mol')
         if isinstance(dataset.mols[0], str):
             rdkit_mols = [MolFromSmiles(mol) for mol in dataset.mols]
         elif isinstance(dataset.mols[0], Mol):
@@ -594,8 +499,7 @@ class SmilesSeqFeat:
         else:
             rdkit_mols = None
 
-        # featurization process using DeepChem featurizers
-        print('Featurizing datapoints')
+        # featurization process using DeepChem SmilesToSeq
         dataset.X = SmilesToSeq(
             char_to_idx=self.char_to_idx,
             max_len=self.max_len,
@@ -604,52 +508,9 @@ class SmilesSeqFeat:
         # identify which rows did not get featurized
         indexes = []
         for i, feat in enumerate(dataset.X):
-            if i % log_every_n == 0:
-                print('Analyzing datapoint %i' % i)
             if len(feat) == 0:
-                print('Failed to featurize datapoint %d, %s' % (i, dataset.mols[i]))
                 indexes.append(i)
         # treat indexes with no featurization
         dataset.remove_elements(indexes)
-        print('Elements with indexes: ', indexes, 'were removed due to lack of featurization.')
         dataset.X = np.asarray([np.asarray(feat, dtype=object) for feat in dataset.X])
-
         return dataset
-
-
-class CGCNNFeat:
-    """
-    Calculate structure graph features for crystals.
-    Adapted from deepchem. Not implemented (outside molecular domain)
-    """
-
-    def __init__(self, radius: float = 8.0, max_neighbors: float = 12, step: float = 0.2):
-        self.radius = radius
-        self.max_neighbors = max_neighbors
-        self.step = step
-
-    def _featurize(self, dataset: Dataset, log_every_n=1000):
-
-        # Dataset is supposed to be composed by structure dictionaries or pymatgen.Structure objects
-        try:
-            from pymatgen import Structure
-        except ModuleNotFoundError:
-            raise ImportError("This class requires pymatgen to be installed")
-
-        pass
-
-
-class RawFeat(MolecularFeaturizer):
-
-    def _featurize(self, mol: Union[Mol, str], log_every_n=1000):
-
-        if isinstance(mol, Mol):
-            smiles = MolToSmiles(mol)
-        elif isinstance(mol, str):
-            smiles = mol
-        else:
-            smiles = None
-
-        mol = RawFeaturizer().featurize([smiles])[0]
-        # dataset.ids = smiles  # this is needed when calling the build_char_dict method (TextCNNModel)
-        return mol

--- a/src/deepmol/datasets/_utils.py
+++ b/src/deepmol/datasets/_utils.py
@@ -58,3 +58,33 @@ def merge_arrays_of_arrays(array1: np.ndarray, array2: np.ndarray) -> Union[np.n
         return None
     merged = np.concatenate([array1, array2], axis=0)
     return merged
+
+
+def check_values(values: Union[np.ndarray, float, int]) -> bool:
+    """
+    Checks if the array is empty or if contains any np.nan values.
+
+    Parameters
+    ----------
+    values: Union[np.ndarray, float, int]
+        The values to check.
+
+    Returns
+    -------
+    bool
+        True if the array is empty or contains np.nan values, False otherwise.
+    """
+    if values is None:
+        return True
+    if isinstance(values, np.ndarray):
+        if values.size == 0:
+            return True
+        if isinstance(values[0], float) or isinstance(values[0], int):
+            if np.isnan(np.dot(values, values)):
+                return True
+            return False
+    if isinstance(values, float) or isinstance(values, int):
+        if np.isnan(values):
+            return True
+        return False
+    return False

--- a/src/deepmol/datasets/datasets.py
+++ b/src/deepmol/datasets/datasets.py
@@ -581,7 +581,7 @@ class NumpyDataset(Dataset):
             for i in X:
                 if len(shape) == 2:
                     # Deal with some DeepChem feature objects
-                    if not isinstance(i[0], float) or not isinstance(i[0], int):
+                    if not isinstance(i[0], float) and not isinstance(i[0], int):
                         pass
                     else:
                         # check if numpy array is empty

--- a/src/deepmol/datasets/datasets.py
+++ b/src/deepmol/datasets/datasets.py
@@ -5,7 +5,7 @@ from typing import Union, List, Tuple
 import numpy as np
 import pandas as pd
 
-from deepmol.datasets._utils import merge_arrays, merge_arrays_of_arrays
+from deepmol.datasets._utils import merge_arrays, merge_arrays_of_arrays, check_values
 
 
 class Dataset(ABC):
@@ -576,22 +576,10 @@ class NumpyDataset(Dataset):
         indexes = []
 
         if axis == 0:
-            shape = self.X.shape
             X = self.X
             for i in X:
-                if len(shape) == 2:
-                    # Deal with some DeepChem feature objects
-                    if not isinstance(i[0], float) and not isinstance(i[0], int):
-                        pass
-                    else:
-                        # check if numpy array is empty
-                        if i.size == 0:
-                            indexes.append(self.ids[j])
-                        elif np.isnan(np.dot(i, i)):
-                            indexes.append(self.ids[j])
-                elif isinstance(i, float) or isinstance(i, int):
-                    if i is None or np.isnan(i):
-                        indexes.append(self.ids[j])
+                if check_values(i):
+                    indexes.append(self.ids[j])
                 j += 1
             if len(indexes) > 0:
                 print('Elements with IDs: ', indexes, ' were removed due to the presence of NAs!')

--- a/src/deepmol/datasets/datasets.py
+++ b/src/deepmol/datasets/datasets.py
@@ -580,8 +580,15 @@ class NumpyDataset(Dataset):
             X = self.X
             for i in X:
                 if len(shape) == 2:
-                    if np.isnan(np.dot(i, i)):
-                        indexes.append(self.ids[j])
+                    # Deal with some DeepChem feature objects
+                    if not isinstance(i[0], float) or not isinstance(i[0], int):
+                        pass
+                    else:
+                        # check if numpy array is empty
+                        if i.size == 0:
+                            indexes.append(self.ids[j])
+                        elif np.isnan(np.dot(i, i)):
+                            indexes.append(self.ids[j])
                 elif isinstance(i, float) or isinstance(i, int):
                     if i is None or np.isnan(i):
                         indexes.append(self.ids[j])

--- a/tests/unit_tests/featurizers/test_deepchem_featurizers.py
+++ b/tests/unit_tests/featurizers/test_deepchem_featurizers.py
@@ -1,27 +1,37 @@
 from copy import copy
-from unittest import TestCase, skip
+from unittest import TestCase
 
-import numpy as np
+from deepmol.compound_featurization import WeaveFeat, ConvMolFeat, MolGraphConvFeat, CoulombFeat, CoulombEigFeat, \
+    SmileImageFeat, SmilesSeqFeat
 
-from deepmol.compound_featurization import WeaveFeat
 from tests.unit_tests.featurizers.test_featurizers import FeaturizerTestCase
 
 
 class TestDeepChemFeaturizers(FeaturizerTestCase, TestCase):
 
+    def validate_featurizer(self, featurizer, df, n_valid, **kwargs):
+        featurizer(**kwargs).featurize(df)
+        features = df.X
+        self.assertEqual(len(features), n_valid)
+
     def test_featurize(self):
-        pass
+        df = copy(self.mock_dataset)
+        valid = len(self.original_smiles)
+        self.validate_featurizer(ConvMolFeat, df, valid)
+        self.validate_featurizer(WeaveFeat, df, valid)
+        self.validate_featurizer(MolGraphConvFeat, df, valid)
+        self.validate_featurizer(CoulombFeat, df, valid, max_atoms=100)
+        self.validate_featurizer(CoulombEigFeat, df, valid, max_atoms=100)
+        self.validate_featurizer(SmileImageFeat, df, valid)
+        self.validate_featurizer(SmilesSeqFeat, df, valid)
 
-    @skip("Not implemented yet")
     def test_featurize_with_nan(self):
-        dataset_rows_number = len(self.mini_dataset_to_test.mols)
-        to_add = np.zeros(4)
-        ids_to_add = np.array([5, 6, 7, 8])
-
-        self.mini_dataset_to_test.mols = np.concatenate((self.mini_dataset_to_test.mols, to_add))
-        self.mini_dataset_to_test.y = np.concatenate((self.mini_dataset_to_test.y, to_add))
-        self.mini_dataset_to_test.ids = np.concatenate((self.mini_dataset_to_test.y, ids_to_add))
-
-        dataset = copy(self.mini_dataset_to_test)
-        WeaveFeat().featurize(dataset)
-        self.assertEqual(dataset_rows_number, dataset.X.shape[0])
+        df = copy(self.mock_dataset_with_invalid)
+        valid = len(self.original_smiles_with_invalid) - 1
+        self.validate_featurizer(ConvMolFeat, df, valid, n_jobs=1)
+        self.validate_featurizer(WeaveFeat, df, valid)
+        self.validate_featurizer(MolGraphConvFeat, df, valid, n_jobs=-1)
+        self.validate_featurizer(CoulombFeat, df, valid, max_atoms=100, seed=123, n_jobs=3)
+        self.validate_featurizer(CoulombEigFeat, df, valid, max_atoms=100, seed=123, n_jobs=2)
+        self.validate_featurizer(SmileImageFeat, df, valid, n_jobs=1)
+        self.validate_featurizer(SmilesSeqFeat, df, valid+1)

--- a/tests/unit_tests/featurizers/test_deepchem_featurizers.py
+++ b/tests/unit_tests/featurizers/test_deepchem_featurizers.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 from deepmol.compound_featurization import WeaveFeat, ConvMolFeat, MolGraphConvFeat, CoulombFeat, CoulombEigFeat, \
     SmileImageFeat, SmilesSeqFeat
+from deepmol.compound_featurization.deepchem_featurizers import MolGanFeat
 
 from tests.unit_tests.featurizers.test_featurizers import FeaturizerTestCase
 
@@ -19,6 +20,8 @@ class TestDeepChemFeaturizers(FeaturizerTestCase, TestCase):
         valid = len(self.original_smiles)
         self.validate_featurizer(ConvMolFeat, df, valid)
         self.validate_featurizer(WeaveFeat, df, valid)
+        self.validate_featurizer(MolGanFeat, df, valid, max_atom_count=15)
+        self.validate_featurizer(MolGanFeat, df, valid-1, max_atom_count=9)  # 1 mol has more than 9 atoms
         self.validate_featurizer(MolGraphConvFeat, df, valid)
         self.validate_featurizer(CoulombFeat, df, valid, max_atoms=100)
         self.validate_featurizer(CoulombEigFeat, df, valid, max_atoms=100)
@@ -30,6 +33,7 @@ class TestDeepChemFeaturizers(FeaturizerTestCase, TestCase):
         valid = len(self.original_smiles_with_invalid) - 1
         self.validate_featurizer(ConvMolFeat, df, valid, n_jobs=1)
         self.validate_featurizer(WeaveFeat, df, valid)
+        self.validate_featurizer(MolGanFeat, df, valid-1)   # 1 mol has more than 9 atoms
         self.validate_featurizer(MolGraphConvFeat, df, valid, n_jobs=-1)
         self.validate_featurizer(CoulombFeat, df, valid, max_atoms=100, seed=123, n_jobs=3)
         self.validate_featurizer(CoulombEigFeat, df, valid, max_atoms=100, seed=123, n_jobs=2)

--- a/tests/unit_tests/featurizers/test_featurizers.py
+++ b/tests/unit_tests/featurizers/test_featurizers.py
@@ -1,14 +1,21 @@
 from abc import abstractmethod, ABC
 
 import os
+from unittest.mock import MagicMock
 
+import numpy as np
+import pandas as pd
+
+from deepmol.datasets import NumpyDataset
 from deepmol.loaders.loaders import CSVLoader
 
 from tests import TEST_DIR
 
+
 class FeaturizerTestCase(ABC):
 
     def setUp(self) -> None:
+        # TODO: remove the dependencies on other modules of DeepMol (use mocks instead)
         self.data_path = os.path.join(TEST_DIR, 'data')
 
         dataset = os.path.join(self.data_path, "test_to_convert_to_sdf.csv")
@@ -26,7 +33,17 @@ class FeaturizerTestCase(ABC):
         self.dataset_invalid_smiles = loader.create_dataset()
 
         self.mol2vec_model = os.path.join(os.path.abspath(os.curdir), "compound_featurization", "mol2vec_models",
-                                        "model_300dim.pkl")
+                                          "model_300dim.pkl")
+
+        data_path = os.path.join(TEST_DIR, 'data/test_to_convert_to_sdf.csv')
+        self.original_smiles = pd.read_csv(data_path, sep=',').Smiles.values
+        self.mock_dataset = MagicMock(spec=NumpyDataset,
+                                      mols=self.original_smiles,
+                                      ids=np.arange(len(self.original_smiles)))
+        self.original_smiles_with_invalid = np.append(self.original_smiles, ['CC(=O)[O-].NC', 'C1=CC=CC=C1('])
+        self.mock_dataset_with_invalid = MagicMock(spec=NumpyDataset,
+                                                   mols=self.original_smiles_with_invalid,
+                                                   ids=np.arange(len(self.original_smiles_with_invalid)))
 
     @abstractmethod
     def test_featurize(self):


### PR DESCRIPTION
A general refactoring of all deepchem featurizers was done including:
- moving utility functions to `_utils.py`
- remove checks to assure mols are RDKit Mol objects (this is handled in the parent class).
- add `**kwargs` to pass other named parameters to the parent class.
- update docstrings and type hints 

Tests for all deepchem featurizers were added.

Classes `RawFeat` and `CGCNNFeat` were removed:
- `RawFeat` is only used to convert Mol objects to SMILES strings or SMILES strings to Mol objects which are handled differently in our package.
- `CGCNNFeat`  is used for calculating structure graph features for crystals (out of our scope).

In the future, it could be interesting to add other featurizers that are now available through the DeepChem framework for molecules (https://deepchem.readthedocs.io/en/latest/api_reference/featurizers.html?highlight=CGCNN#molecule-featurizers).
Note: some of the new featurizers are only available in newer versions of deepchem.

This PR closes #12 .
