### PR TITLE
[HOTFIX] return morgan fingerprint as numpy array

### DIFF
--- a/src/deepmol/compound_featurization/rdkit_fingerprints.py
+++ b/src/deepmol/compound_featurization/rdkit_fingerprints.py
@@ -59,6 +59,7 @@ class MorganFingerprint(MolecularFeaturizer):
                                                             useChirality=self.chiral,
                                                             useBondTypes=self.bonds,
                                                             useFeatures=self.features)
+        fp = np.asarray(fp, dtype=np.float32)
         return fp
 
 


### PR DESCRIPTION
MorganFingerprint was not being returned as a numpy array like every other fingerprint in DeepMol.