### PR TITLE
[HOTFIX] MACCSkeys are 167 not 166

### DIFF
--- a/src/deepmol/compound_featurization/rdkit_fingerprints.py
+++ b/src/deepmol/compound_featurization/rdkit_fingerprints.py
@@ -74,7 +74,7 @@ class MACCSkeysFingerprint(MolecularFeaturizer):
         Initialize a MACCSkeysFingerprint object.
         """
         super().__init__(**kwargs)
-        self.feature_names = [f'maccs_{i}' for i in range(166)]
+        self.feature_names = [f'maccs_{i}' for i in range(167)]
 
     def _featurize(self, mol: Mol) -> np.ndarray:
         """


### PR DESCRIPTION
MACCSkeysFingerprint feature_names were being created with the wrong size of 166 instead of 167.