### PR TITLE
Hot fix dependencies - changing the dependencies for their most stable and least vulnerable version

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -15,7 +15,7 @@ chembl_structure_pipeline==1.1.0: preprocessing
 torch==2.0.0: deep_learning
 dgl==0.9.1: deep_learning
 deepchem==2.7.1: deep_learning
-tensorflow==2.12.0: deep_learning
+tensorflow==2.11.0: deep_learning
 boruta==0.3: preprocessing
 scikit-learn==1.2.0: machine_learning, deep_learning
 pytest>=7.1.1: test

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -12,12 +12,10 @@ kneed==0.8.2: machine_learning
 kaleido==0.2.1: machine_learning
 plotly==5.13.1: machine_learning
 chembl_structure_pipeline==1.1.0: preprocessing
-torch==1.12.1: deep_learning
-torchvision==0.13.1: deep_learning
-torchaudio==0.12.1: deep_learning
+torch==2.0.0: deep_learning
 dgl==0.9.1: deep_learning
-deepchem==2.5.0: deep_learning
-tensorflow==2.10.0: deep_learning
+deepchem==2.7.1: deep_learning
+tensorflow==2.12.0: deep_learning
 boruta==0.3: preprocessing
 scikit-learn==1.2.0: machine_learning, deep_learning
 pytest>=7.1.1: test

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ shap==0.41.0
 gensim==4.2.0
 mol2vec @ git+https://github.com/samoturk/mol2vec#egg=mol2vec
 boruta==0.3
-tensorflow==2.12.0
+tensorflow==2.11.0
 chembl_structure_pipeline==1.1.0
 scikit-learn==1.1.3
 imblearn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,17 @@
 rdkit-pypi==2022.3.5
 smilespe==0.0.3
 seaborn==0.12.0
-torch==1.12.1
-torchvision==0.13.1
-torchaudio==0.12.1
+torch==2.0.0
 dgl==0.9.1
 joblib==1.1.1
 pillow==8.4.0
 h5py==3.7.0
-deepchem==2.5.0
+deepchem==2.7.1
 shap==0.41.0
 gensim==4.2.0
 mol2vec @ git+https://github.com/samoturk/mol2vec#egg=mol2vec
 boruta==0.3
-tensorflow==2.10.0
+tensorflow==2.12.0
 chembl_structure_pipeline==1.1.0
 scikit-learn==1.1.3
 imblearn

--- a/tests/unit_tests/hyperparameter_optimisation/test_deep_chem_hyperparameter_optimization.py
+++ b/tests/unit_tests/hyperparameter_optimisation/test_deep_chem_hyperparameter_optimization.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -11,6 +12,8 @@ from deepmol.metrics import Metric
 from deepmol.models import DeepChemModel
 from deepmol.parameter_optimization import HyperparameterOptimizerCV
 from unit_tests.models.test_models import ModelsTestCase
+
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 
 class TestDeepChemHyperparameterOptimization(ModelsTestCase, TestCase):

--- a/tests/unit_tests/models/test_deepchem_model.py
+++ b/tests/unit_tests/models/test_deepchem_model.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 
 import numpy as np
@@ -12,14 +13,18 @@ from deepmol.metrics import Metric
 from deepmol.models import DeepChemModel
 from unit_tests.models.test_models import ModelsTestCase
 
+import tensorflow as tf
+
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
 
 class TestDeepChemModel(ModelsTestCase, TestCase):
 
     def test_fit_predict_evaluate(self):
         ds_train = self.binary_dataset
-        ds_train.X = ConvMolFeaturizer().featurize([MolFromSmiles('CCC')]*100)
+        ds_train.X = ConvMolFeaturizer().featurize([MolFromSmiles('CCC')] * 100)
         ds_test = self.binary_dataset_test
-        ds_test.X = ConvMolFeaturizer().featurize([MolFromSmiles('CCC')]*10)
+        ds_test.X = ConvMolFeaturizer().featurize([MolFromSmiles('CCC')] * 10)
 
         graph = GraphConvModel(n_tasks=1, mode='classification')
         model_graph = DeepChemModel(graph)
@@ -50,9 +55,9 @@ class TestDeepChemModel(ModelsTestCase, TestCase):
 
     def test_multiclass(self):
         ds_train = self.multitask_dataset
-        ds_train.X = ConvMolFeaturizer().featurize([MolFromSmiles('CCC')]*100)
+        ds_train.X = ConvMolFeaturizer().featurize([MolFromSmiles('CCC')] * 100)
         ds_test = self.multitask_dataset_test
-        ds_test.X = ConvMolFeaturizer().featurize([MolFromSmiles('CCC')]*10)
+        ds_test.X = ConvMolFeaturizer().featurize([MolFromSmiles('CCC')] * 10)
 
         graph = GraphConvModel(n_tasks=ds_train.n_tasks, mode='classification')
         model_graph = DeepChemModel(graph)


### PR DESCRIPTION
This PR closes issue #42.

Changed versions of torch, deepchem and tensorflow. Removed dependencies of torchvision and torchaudio as none of our models depend on these packages. 

- torch 1.12.1 to 2.0.0
- tensorflow 2.10.0 to 2.11.0
- deepchem 2.5.0 to 2.7.1