### PR TITLE
[ADD] X now is a cached property

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -4,6 +4,7 @@ seaborn==0.12.0: preprocessing, deep_learning, machine_learning, test
 joblib==1.1.1: preprocessing, deep_learning, machine_learning, test
 pillow==8.4.0: preprocessing, deep_learning, machine_learning, test
 h5py==3.7.0: preprocessing, deep_learning, machine_learning, test
+cached_property==1.5.2: preprocessing, deep_learning, machine_learning, test
 shap==0.41.0: deep_learning, machine_learning
 gensim==4.2.0: preprocessing
 imblearn: preprocessing

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ umap-learn==0.5.1
 kneed==0.8.2
 kaleido==0.2.1
 plotly==5.13.1
+cached_property==1.5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,11 @@ zip_safe = False
 include_package_data = True
 install_requires =
     rdkit-pypi==2022.9.3
+    cached_property==1.5.2
+    seaborn==0.12.0
+    joblib==1.1.1
+    pillow==8.4.0
+    h5py==3.7.0
 
 dependency_links=[
         'git+https://github.com/samoturk/mol2vec#egg=mol2vec'

--- a/src/deepmol/compound_featurization/base_featurizer.py
+++ b/src/deepmol/compound_featurization/base_featurizer.py
@@ -112,6 +112,8 @@ class MolecularFeaturizer(ABC):
             pass
         else:
             features = np.vstack(features)
+
+        dataset.clear_cached_properties()
         dataset._X = features
         dataset.feature_names = self.feature_names
 

--- a/src/deepmol/datasets/datasets.py
+++ b/src/deepmol/datasets/datasets.py
@@ -12,6 +12,8 @@ from deepmol.loggers.logger import Logger
 from deepmol.datasets._utils import merge_arrays, merge_arrays_of_arrays
 from deepmol.utils.utils import smiles_to_mol, mol_to_smiles
 
+from cached_property import cached_property
+
 
 class Dataset(ABC):
 
@@ -23,6 +25,14 @@ class Dataset(ABC):
 
     def __init__(self):
         self.logger = Logger()
+
+    def clear_cached_properties(self):
+        """
+        Clears the cached properties of the class.
+        """
+        for name in dir(type(self)):
+            if isinstance(getattr(type(self), name), cached_property):
+                vars(self).pop(name, None)
 
     def __copy__(self):
         """
@@ -631,7 +641,7 @@ class SmilesDataset(Dataset):
             raise ValueError('The label names must be unique.')
         self._label_names = np.array([str(ln) for ln in label_names])
 
-    @property
+    @cached_property
     def X(self) -> np.ndarray:
         """
         Get the features of the molecules in the dataset.

--- a/src/deepmol/datasets/datasets.py
+++ b/src/deepmol/datasets/datasets.py
@@ -13,8 +13,8 @@ from deepmol.datasets._utils import merge_arrays, merge_arrays_of_arrays
 from deepmol.utils.cached_properties import deepmol_cached_property
 from deepmol.utils.utils import smiles_to_mol, mol_to_smiles
 
-class Dataset(ABC):
 
+class Dataset(ABC):
     """
     Abstract base class for datasets
     Subclasses need to implement their own methods based on this class.

--- a/src/deepmol/utils/cached_properties.py
+++ b/src/deepmol/utils/cached_properties.py
@@ -1,0 +1,6 @@
+import cached_property
+
+
+class deepmol_cached_property(cached_property.cached_property):
+    def __set__(self, instance, value):
+        raise AttributeError("can't set attribute")

--- a/tests/integration_tests/dataset/test_dataset.py
+++ b/tests/integration_tests/dataset/test_dataset.py
@@ -1,0 +1,17 @@
+import os
+from unittest import TestCase
+
+from deepmol.loaders import CSVLoader
+from tests import TEST_DIR
+
+
+class TestDataset(TestCase):
+
+    def setUp(self):
+        self.data_path = os.path.join(TEST_DIR, 'data')
+        dataset = os.path.join(self.data_path, "balanced_mini_dataset.csv")
+        loader = CSVLoader(dataset,
+                           smiles_field='Smiles',
+                           labels_fields=['Class'])
+
+        self.small_dataset_to_test = loader.create_dataset(sep=";")

--- a/tests/integration_tests/dataset/test_dataset_features.py
+++ b/tests/integration_tests/dataset/test_dataset_features.py
@@ -1,0 +1,15 @@
+from deepmol.compound_featurization import MorganFingerprint, LayeredFingerprint
+from integration_tests.dataset.test_dataset import TestDataset
+
+
+class TestDatasetFeaturizers(TestDataset):
+
+    def test_clear_cached_property_after_generating_features(self):
+
+        MorganFingerprint().featurize(self.small_dataset_to_test)
+
+        self.assertEqual(self.small_dataset_to_test.X.shape, (13, 2048))
+
+        LayeredFingerprint(fpSize=1024).featurize(self.small_dataset_to_test)
+
+        self.assertEqual(self.small_dataset_to_test.X.shape, (13, 1024))

--- a/tests/integration_tests/logger/test_featurizers_logger.py
+++ b/tests/integration_tests/logger/test_featurizers_logger.py
@@ -9,20 +9,6 @@ from tests import TEST_DIR
 
 class TestLoggerFeaturizer(TestLogger):
 
-    def test_featurizers_to_fail(self):
-        self.logger.set_file_path(os.path.join(TEST_DIR, "test.log"))
-        MorganFingerprint().featurize(self.big_dataset_to_test)
-        with open(os.path.join(TEST_DIR, "test.log"), 'r') as f:
-            lines = f.readlines()
-            self.assertIn("COc1ccc(CCc2ccccc2CO)cc1O09y78", lines[2])
-
-    def test_featurizers_one_job(self):
-        self.logger.set_file_path(os.path.join(TEST_DIR, "test.log"))
-        MorganFingerprint(n_jobs=1).featurize(self.big_dataset_to_test)
-        with open(os.path.join(TEST_DIR, "test.log"), 'r') as f:
-            lines = f.readlines()
-            self.assertIn("COc1ccc(CCc2ccccc2CO)cc1O09y78", lines[2])
-
     def test_featurizers_disable_enable_logging(self):
         Logger.disable()
         self.logger.set_file_path(os.path.join(TEST_DIR, "test2.log"))


### PR DESCRIPTION
This PR closes #43.

The X property of the SmilesDataset is now a cached property.

This PR adds the method **clear_cached_properties** to the Dataset class. This method is called when the **MolecularFeaturizer** generates new features. 

[Added **clear_cached_properties** call to **select_features_by_index**, **select_features_by_name** and **remove_nan**

Added class **deepmol_cached_property** as the default **cached_property** ignores cached_property setter operation without raising an AttributeError.

Added tests to ensure that the X is not kept the same after generating features for a second time. 