### PR TITLE
Imbalanced learn tracking

### DIFF
--- a/src/deepmol/imbalanced_learn/_utils.py
+++ b/src/deepmol/imbalanced_learn/_utils.py
@@ -1,0 +1,31 @@
+import uuid
+
+import numpy as np
+
+
+def _get_new_ids(original_x: np.array, new_x, original_ids):
+    """
+    Get new ids for the new dataset.
+
+    Parameters
+    ----------
+    original_x: np.array
+        Original dataset.
+    new_x: np.array
+        Sampled dataset.
+    original_ids: np.array
+        Original ids.
+
+    Returns
+    -------
+    np.array
+        Ids of the sampled dataset.
+    """
+    ids = []
+    for i in range(new_x.shape[0]):
+        # check if the sample is artificial or not be checcking if the row is in the original dataset
+        if np.any(np.all(new_x[i] == original_x, axis=1)):
+            ids.append(original_ids[np.where(np.all(new_x[i] == original_x, axis=1))[0][0]])
+        else:
+            ids.append(f"ib_{uuid.uuid4().hex}")
+    return np.array(ids)

--- a/tests/unit_tests/imbalanced_learn/test_imbalanced_learn.py
+++ b/tests/unit_tests/imbalanced_learn/test_imbalanced_learn.py
@@ -3,11 +3,11 @@ import os
 from unittest import TestCase
 
 import numpy as np
-import pandas as pd
+from imblearn.over_sampling import SMOTE as SMOTE_IB
 
 from deepmol.datasets import SmilesDataset
-from deepmol.imbalanced_learn import RandomOverSampler, SMOTE
-from tests import TEST_DIR
+from deepmol.imbalanced_learn import RandomOverSampler, SMOTE, ClusterCentroids, RandomUnderSampler, SMOTEENN, \
+    SMOTETomek
 from unit_tests._mock_utils import SmilesDatasetMagicMock
 
 
@@ -15,12 +15,11 @@ class TestImbalancedLearn(TestCase):
 
     def setUp(self) -> None:
         # create a dataset with 10 samples and 5 features
-        x = np.random.randint(0, 10, size=(10, 5))
+        x = np.random.randint(0, 10, size=(14, 5))
         # y with 8 samples of class 0 and 2 samples of class 1
-        y = np.zeros(8)
-        y = np.append(y, np.ones(2))
+        y = np.array([1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0])
         # ids 10 characters from the alphabet
-        ids = np.array([''.join(np.random.choice(list('abcdefghij'), 10)) for _ in range(10)])
+        ids = np.array([''.join(np.random.choice(list('abcdefghij'), 14)) for _ in range(14)])
         self.imbalanced_dataset = SmilesDatasetMagicMock(spec=SmilesDataset,
                                                          X=x,
                                                          y=y,
@@ -41,9 +40,49 @@ class TestImbalancedLearn(TestCase):
 
     def test_smote(self):
         df = copy.deepcopy(self.imbalanced_dataset)
-        new_df = SMOTE().sample(df)
+        new_df = SMOTE(k_neighbors=1).sample(df)
         self.assertTrue(new_df._X.shape[0] > df.X.shape[0])
         # assert under-represented class is oversampled
         self.assertTrue(np.sum(new_df._y == 1) > np.sum(df.y == 1))
+        # assert ids are not duplicated
+        self.assertEqual(len(np.unique(new_df._ids)), len(new_df._ids))
+
+    def test_cluster_centroids(self):
+        df = copy.deepcopy(self.imbalanced_dataset)
+        new_df = ClusterCentroids().sample(df)
+        self.assertTrue(new_df._X.shape[0] < df.X.shape[0])
+        # assert over-represented class is undersampled
+        self.assertTrue(np.sum(new_df._y == 0) < np.sum(df.y == 0))
+        # assert ids are not duplicated
+        self.assertEqual(len(np.unique(new_df._ids)), len(new_df._ids))
+
+    def test_random_under_sampler(self):
+        df = copy.deepcopy(self.imbalanced_dataset)
+        new_df = RandomUnderSampler().sample(df)
+        self.assertTrue(new_df._X.shape[0] < df.X.shape[0])
+        # assert over-represented class is undersampled
+        self.assertTrue(np.sum(new_df._y == 0) < np.sum(df.y == 0))
+        # assert ids are not duplicated
+        self.assertEqual(len(np.unique(new_df._ids)), len(new_df._ids))
+
+    def test_SMOTEENN(self):
+        df = copy.deepcopy(self.imbalanced_dataset)
+        smote = SMOTE_IB(k_neighbors=1)
+        new_df = SMOTEENN(smote=smote).sample(df)
+        # assert under-represented class is oversampled
+        self.assertTrue(np.sum(new_df._y == 1) > np.sum(df.y == 1))
+        # assert over-represented class is undersampled
+        self.assertTrue(np.sum(new_df._y == 0) < np.sum(df.y == 0))
+        # assert ids are not duplicated
+        self.assertEqual(len(np.unique(new_df._ids)), len(new_df._ids))
+
+    def test_SMOTETomek(self):
+        df = copy.deepcopy(self.imbalanced_dataset)
+        smote = SMOTE_IB(k_neighbors=2)
+        new_df = SMOTETomek(smote=smote).sample(df)
+        # assert under-represented class is oversampled
+        self.assertTrue(np.sum(new_df._y == 1) > np.sum(df.y == 1))
+        # assert over-represented class is undersampled
+        self.assertTrue(np.sum(new_df._y == 0) <= np.sum(df.y == 0))
         # assert ids are not duplicated
         self.assertEqual(len(np.unique(new_df._ids)), len(new_df._ids))

--- a/tests/unit_tests/imbalanced_learn/test_imbalanced_learn.py
+++ b/tests/unit_tests/imbalanced_learn/test_imbalanced_learn.py
@@ -1,0 +1,49 @@
+import copy
+import os
+from unittest import TestCase
+
+import numpy as np
+import pandas as pd
+
+from deepmol.datasets import SmilesDataset
+from deepmol.imbalanced_learn import RandomOverSampler, SMOTE
+from tests import TEST_DIR
+from unit_tests._mock_utils import SmilesDatasetMagicMock
+
+
+class TestImbalancedLearn(TestCase):
+
+    def setUp(self) -> None:
+        # create a dataset with 10 samples and 5 features
+        x = np.random.randint(0, 10, size=(10, 5))
+        # y with 8 samples of class 0 and 2 samples of class 1
+        y = np.zeros(8)
+        y = np.append(y, np.ones(2))
+        # ids 10 characters from the alphabet
+        ids = np.array([''.join(np.random.choice(list('abcdefghij'), 10)) for _ in range(10)])
+        self.imbalanced_dataset = SmilesDatasetMagicMock(spec=SmilesDataset,
+                                                         X=x,
+                                                         y=y,
+                                                         ids=ids)
+
+    def tearDown(self) -> None:
+        if os.path.exists('deepmol.log'):
+            os.remove('deepmol.log')
+
+    def test_random_over_sampler(self):
+        df = copy.deepcopy(self.imbalanced_dataset)
+        new_df = RandomOverSampler().sample(df)
+        self.assertTrue(new_df._X.shape[0] > df.X.shape[0])
+        # assert under-represented class is oversampled
+        self.assertTrue(np.sum(new_df._y == 1) > np.sum(df.y == 1))
+        # assert ids are not duplicated
+        self.assertEqual(len(np.unique(new_df._ids)), len(new_df._ids))
+
+    def test_smote(self):
+        df = copy.deepcopy(self.imbalanced_dataset)
+        new_df = SMOTE().sample(df)
+        self.assertTrue(new_df._X.shape[0] > df.X.shape[0])
+        # assert under-represented class is oversampled
+        self.assertTrue(np.sum(new_df._y == 1) > np.sum(df.y == 1))
+        # assert ids are not duplicated
+        self.assertEqual(len(np.unique(new_df._ids)), len(new_df._ids))


### PR DESCRIPTION
Tracking of ids of added/removed/kept samples is now supported. Previously, the dataset undergoing under/oversampling would have incoherent ids. This is now fixed.

Tests of the imbalanced_learn module were also added.

Closes #63 .