### PR TITLE
[FIX] categorical_choices to be compatible with optuna-dashboard

### DIFF
--- a/src/deepmol/pipeline_optimization/_deepchem_models_objectives.py
+++ b/src/deepmol/pipeline_optimization/_deepchem_models_objectives.py
@@ -36,8 +36,8 @@ def gat_model_steps(trial: Trial, model_dir: str = 'gat_model/', gat_kwargs: dic
     # model
     n_attention_heads = trial.suggest_int('n_attention_heads', 4, 10, step=2)
     gat_kwargs['n_attention_heads'] = n_attention_heads
-    agg_modes = trial.suggest_categorical('agg_modes', [['mean'], ['flatten']])
-    gat_kwargs['agg_modes'] = agg_modes
+    agg_modes = trial.suggest_categorical('agg_modes', [str(cat) for cat in [['mean'], ['flatten']]])
+    gat_kwargs['agg_modes'] = eval(agg_modes)
     dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
     gat_kwargs['dropout'] = dropout
     predictor_dropout = trial.suggest_float('predictor_dropout', 0.0, 0.5, step=0.25)
@@ -72,8 +72,9 @@ def gcn_model_steps(trial: Trial, model_dir: str = 'gcn_model/', gcn_kwargs: dic
     # MolGraphConvFeaturizer
     featurizer = MolGraphConvFeat()
     # model
-    graph_conv_layers = trial.suggest_categorical('graph_conv_layers', [[32, 64], [64, 64], [64, 128]])
-    gcn_kwargs['graph_conv_layers'] = graph_conv_layers
+    graph_conv_layers = trial.suggest_categorical('graph_conv_layers',
+                                                  [str(cat) for cat in [[32, 64], [64, 64], [64, 128]]])
+    gcn_kwargs['graph_conv_layers'] = eval(graph_conv_layers)
     batchnorm = trial.suggest_categorical('batchnorm', [True, False])
     gcn_kwargs['batchnorm'] = batchnorm
     dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
@@ -282,8 +283,9 @@ def cnn_model_steps(trial: Trial, model_dir: str = 'cnn_model/', cnn_kwargs: dic
     """
     # Classifier/ Regressor
     # works with 1D, 2D and 3D data
-    layer_filters = trial.suggest_categorical('layer_filters', [[100], [100, 100], [100, 100, 100]])
-    cnn_kwargs['layer_filters'] = layer_filters
+    layer_filters = trial.suggest_categorical('layer_filters',
+                                              [str(cat) for cat in [[100], [100, 100], [100, 100, 100]]])
+    cnn_kwargs['layer_filters'] = eval(layer_filters)
     kernel_size = trial.suggest_int('kernel_size', 3, 6)
     cnn_kwargs['kernel_size'] = kernel_size
     dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
@@ -319,8 +321,8 @@ def multitask_classifier_model_steps(trial: Trial, model_dir: str = 'multitask_c
     # 1D descriptors
     dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
     multitask_classifier_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [[50], [100], [500], [200, 100]])
-    multitask_classifier_kwargs['layer_sizes'] = layer_sizes
+    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    multitask_classifier_kwargs['layer_sizes'] = eval(layer_sizes)
     model = multitask_classifier_model(model_dir=model_dir, multitask_classifier_kwargs=multitask_classifier_kwargs,
                                        deepchem_kwargs=deepchem_kwargs)
     return [('model', model)]
@@ -387,8 +389,8 @@ def progressive_multitask_classifier_model_steps(trial: Trial,
     # 1D Descriptors
     dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
     progressive_multitask_classifier_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [[50], [100], [500], [200, 100]])
-    progressive_multitask_classifier_kwargs['layer_sizes'] = layer_sizes
+    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    progressive_multitask_classifier_kwargs['layer_sizes'] = eval(layer_sizes)
     model = progressive_multitask_classifier_model(model_dir=model_dir,
                                                    progressive_multitask_classifier_kwargs=progressive_multitask_classifier_kwargs,
                                                    deepchem_kwargs=deepchem_kwargs)
@@ -422,8 +424,8 @@ def robust_multitask_classifier_model_steps(trial: Trial, model_dir: str = 'robu
     # 1D Descriptors
     dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
     robust_multitask_classifier_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [[50], [100], [500], [200, 100]])
-    robust_multitask_classifier_kwargs['layer_sizes'] = layer_sizes
+    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    robust_multitask_classifier_kwargs['layer_sizes'] = eval(layer_sizes)
     bypass_dropouts = trial.suggest_float('bypass_dropout', 0.0, 0.5, step=0.25)
     robust_multitask_classifier_kwargs['bypass_dropouts'] = bypass_dropouts
     model = robust_multitask_classifier_model(model_dir=model_dir,
@@ -458,8 +460,9 @@ def sc_score_model_steps(trial: Trial, model_dir: str = 'sc_score_model/', sc_sc
     # 1D Descriptors
     dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
     sc_score_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [[100, 100, 100], [300, 300, 300], [500, 200, 100]])
-    sc_score_kwargs['layer_sizes'] = layer_sizes
+    layer_sizes = trial.suggest_categorical('layer_sizes',
+                                            [str(cat) for cat in [[100, 100, 100], [300, 300, 300], [500, 200, 100]]])
+    sc_score_kwargs['layer_sizes'] = eval(layer_sizes)
     model = sc_score_model(model_dir=model_dir, sc_score_kwargs=sc_score_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('model', model)]
 
@@ -521,8 +524,8 @@ def dag_model_steps(trial: Trial, model_dir: str = 'dag_model/', dag_kwargs: dic
     # Classifier/ Regressor
     # ConvMolFeaturizer
     featurizer = ConvMolFeat()
-    layer_sizes = trial.suggest_categorical('layer_sizes', [[50], [100], [500], [200, 100]])
-    dag_kwargs['layer_sizes'] = layer_sizes
+    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    dag_kwargs['layer_sizes'] = eval(layer_sizes)
     transformer = DagTransformer()
     model = dag_model(model_dir=model_dir, dag_kwargs=dag_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('featurizer', featurizer), ('transformer', transformer), ('model', model)]
@@ -553,11 +556,10 @@ def graph_conv_model_steps(trial: Trial, model_dir: str = 'graph_conv_model/', g
     # Classifier/ Regressor
     # ConvMolFeaturizer
     featurizer = ConvMolFeat()
-    graph_conv_layers = trial.suggest_categorical('graph_conv_layers_conv_model', [[64, 64],
-                                                                                   [128, 64],
-                                                                                   [256, 128],
-                                                                                   [256, 128, 64]])
-    graph_conv_kwargs['graph_conv_layers'] = graph_conv_layers
+    graph_conv_layers = trial.suggest_categorical('graph_conv_layers_conv_model',
+                                                  [str(cat) for cat in [[64, 64], [128, 64],
+                                                                        [256, 128], [256, 128, 64]]])
+    graph_conv_kwargs['graph_conv_layers'] = eval(graph_conv_layers)
     dense_layer_size = trial.suggest_categorical('dense_layer_size', [128, 256, 512])
     graph_conv_kwargs['dense_layer_size'] = dense_layer_size
     dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
@@ -778,8 +780,8 @@ def progressive_multitask_regressor_model_steps(trial: Trial, model_dir: str = '
     # 1D Descriptors
     dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
     progressive_multitask_regressor_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [[50], [100], [500], [200, 100]])
-    progressive_multitask_regressor_kwargs['layer_sizes'] = layer_sizes
+    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    progressive_multitask_regressor_kwargs['layer_sizes'] = eval(layer_sizes)
     model = progressive_multitask_regressor_model(model_dir=model_dir,
                                                   progressive_multitask_regressor_kwargs=progressive_multitask_regressor_kwargs,
                                                   deepchem_kwargs=deepchem_kwargs)
@@ -813,8 +815,8 @@ def multitask_regressor_model_steps(trial: Trial, model_dir: str = 'multitask_re
     # 1D Descriptors
     dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
     multitask_regressor_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [[50], [100], [500], [200, 100]])
-    multitask_regressor_kwargs['layer_sizes'] = layer_sizes
+    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    multitask_regressor_kwargs['layer_sizes'] = eval(layer_sizes)
     model = multitask_regressor_model(model_dir=model_dir, multitask_regressor_kwargs=multitask_regressor_kwargs,
                                       deepchem_kwargs=deepchem_kwargs)
     return [('model', model)]
@@ -847,8 +849,8 @@ def robust_multitask_regressor_model_steps(trial: Trial, model_dir: str = 'robus
     # 1D Descriptors
     dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
     robust_multitask_regressor_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [[50], [100], [500], [200, 100]])
-    robust_multitask_regressor_kwargs['layer_sizes'] = layer_sizes
+    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    robust_multitask_regressor_kwargs['layer_sizes'] = eval(layer_sizes)
     bypass_dropouts = trial.suggest_float('bypass_dropout', 0.0, 0.5, step=0.25)
     robust_multitask_regressor_kwargs['bypass_dropouts'] = bypass_dropouts
     model = robust_multitask_regressor_model(model_dir=model_dir,

--- a/src/deepmol/pipeline_optimization/_deepchem_models_objectives.py
+++ b/src/deepmol/pipeline_optimization/_deepchem_models_objectives.py
@@ -34,7 +34,7 @@ def gat_model_steps(trial: Trial, model_dir: str = 'gat_model/', gat_kwargs: dic
     # MolGraphConvFeaturizer
     featurizer = MolGraphConvFeat()
     # model
-    n_attention_heads = trial.suggest_int('n_attention_heads', 4, 10, step=2)
+    n_attention_heads = trial.suggest_categorical('n_attention_heads', [4, 6, 8, 10])
     gat_kwargs['n_attention_heads'] = n_attention_heads
     agg_modes = trial.suggest_categorical('agg_modes', [str(cat) for cat in [['mean'], ['flatten']]])
     gat_kwargs['agg_modes'] = eval(agg_modes)

--- a/src/deepmol/pipeline_optimization/_keras_model_objectives.py
+++ b/src/deepmol/pipeline_optimization/_keras_model_objectives.py
@@ -95,9 +95,10 @@ def keras_1d_cnn_step(trial: Trial, input_shape: tuple, label_names: List[str] =
     filters = [trial.suggest_int(f'filter_{i}', 4, 32) for i in range(n_conv_layers)]
     kernel_sizes = [trial.suggest_int(f'kernel_size_{i}', 16, 64) for i in range(n_conv_layers)]
     strides = [trial.suggest_int(f'stride_{i}', 1, 2) for i in range(n_conv_layers)]
-    conv_activations = [trial.suggest_categorical('conv_activation', ['relu', 'tanh']) for i in range(n_conv_layers)]
-    conv_dropouts = [trial.suggest_float('conv_dropout', 0.0, 0.8) for i in range(n_conv_layers)]
-    conv_batch_norms = [trial.suggest_categorical('conv_batch_norm', [True, False]) for i in range(n_conv_layers)]
+    conv_activations = [trial.suggest_categorical(f'conv_activation_{i}',
+                                                  ['relu', 'tanh']) for i in range(n_conv_layers)]
+    conv_dropouts = [trial.suggest_float(f'conv_dropout_{i}', 0.0, 0.8) for i in range(n_conv_layers)]
+    conv_batch_norms = [trial.suggest_categorical(f'conv_batch_norm_{i}', [True, False]) for i in range(n_conv_layers)]
     dense_units = trial.suggest_int('dense_units', 32, 256, step=32)
     dense_activation = trial.suggest_categorical('dense_activation', ['relu', 'tanh'])
     dense_dropout = trial.suggest_float('dropout', 0.0, 0.8)
@@ -147,9 +148,9 @@ def keras_tabular_transformer_step(trial: Trial, input_shape: tuple, label_names
     embedding_output_dim = trial.suggest_categorical('embedding_output_dim', [8, 16, 32, 64, 128])
     n_attention_layers = trial.suggest_categorical('n_attention_layers', [1, 2, 3, 4])
     n_attention_heads = trial.suggest_categorical('n_attention_heads', [1, 2, 4, 8])
-    attention_dropouts = [trial.suggest_float('attention_dropout', 0.0, 0.5) for _ in range(n_attention_layers)]
-    attention_key_dims = [trial.suggest_categorical('attention_key_dim', [2, 4, 8, 16])
-                          for _ in range(n_attention_layers)]
+    attention_dropouts = [trial.suggest_float(f'attention_dropout_{i}', 0.0, 0.5) for i in range(n_attention_layers)]
+    attention_key_dims = [trial.suggest_categorical(f'attention_key_dim_{i}', [2, 4, 8, 16])
+                          for i in range(n_attention_layers)]
     dense_units = trial.suggest_int('dense_units', 8, 128, step=8)
     dense_activation = trial.suggest_categorical('dense_activation', ['relu', 'tanh'])
     dense_dropout = trial.suggest_float('dense_dropout', 0.0, 0.5)

--- a/src/deepmol/pipeline_optimization/_scaler_objectives.py
+++ b/src/deepmol/pipeline_optimization/_scaler_objectives.py
@@ -71,8 +71,9 @@ def robust_scaler_step(trial) -> Transformer:
     """
     with_centering = trial.suggest_categorical("with_centering", [True, False])
     with_scaling = trial.suggest_categorical("with_scaling", [True, False])
-    quantile_range = trial.suggest_categorical("quantile_range", [(25.0, 75.0), (10.0, 90.0), (5.0, 95.0)])
-    return RobustScaler(with_centering=with_centering, with_scaling=with_scaling, quantile_range=quantile_range)
+    quantile_range = trial.suggest_categorical("quantile_range",
+                                               [str(cat) for cat in [(25.0, 75.0), (10.0, 90.0), (5.0, 95.0)]])
+    return RobustScaler(with_centering=with_centering, with_scaling=with_scaling, quantile_range=eval(quantile_range))
 
 
 def normalizer_step(trial) -> Transformer:

--- a/src/deepmol/pipeline_optimization/_sklearn_model_objectives.py
+++ b/src/deepmol/pipeline_optimization/_sklearn_model_objectives.py
@@ -1830,10 +1830,11 @@ def mlp_regressor_step(trial):
     Regressor
         The MLPRegressor object step.
     """
-    hidden_layer_sizes = trial.suggest_categorical("hidden_layer_sizes", [(50,), (100,), (50, 50), (100, 50)])
+    hidden_layer_sizes = trial.suggest_categorical("hidden_layer_sizes",
+                                                   [str(cat) for cat in [(50,), (100,), (50, 50), (100, 50)]])
     activation = trial.suggest_categorical("activation", ["relu", "tanh"])
     alpha = trial.suggest_loguniform("alpha", 1e-5, 1e-2)
-    mlp_regressor_kwargs = {'hidden_layer_sizes': hidden_layer_sizes, 'activation': activation, 'alpha': alpha}
+    mlp_regressor_kwargs = {'hidden_layer_sizes': eval(hidden_layer_sizes), 'activation': activation, 'alpha': alpha}
     return mlp_regressor_model(mlp_regressor_kwargs=mlp_regressor_kwargs)
 
 
@@ -1851,10 +1852,11 @@ def mlp_classifier_step(trial):
     Classifier
         The MLPClassifier object step.
     """
-    hidden_layer_sizes = trial.suggest_categorical("hidden_layer_sizes", [(50,), (100,), (50, 50), (100, 50)])
+    hidden_layer_sizes = trial.suggest_categorical("hidden_layer_sizes",
+                                                   [str(cat) for cat in [(50,), (100,), (50, 50), (100, 50)]])
     activation = trial.suggest_categorical("activation", ["relu", "tanh"])
     alpha = trial.suggest_loguniform("alpha", 1e-5, 1e-2)
-    mlp_classifier_kwargs = {'hidden_layer_sizes': hidden_layer_sizes, 'activation': activation, 'alpha': alpha}
+    mlp_classifier_kwargs = {'hidden_layer_sizes': eval(hidden_layer_sizes), 'activation': activation, 'alpha': alpha}
     return mlp_classifier_model(mlp_classifier_kwargs=mlp_classifier_kwargs)
 
 

--- a/tests/integration_tests/pipeline_optimization/test_pipeline_optimization.py
+++ b/tests/integration_tests/pipeline_optimization/test_pipeline_optimization.py
@@ -202,6 +202,7 @@ class TestPipelineOptimization(TestCase):
         if param_importance is not None:
             for param in param_importance:
                 self.assertTrue(param in po.best_params.keys())
+
     @skip("This test is too slow to run on CI and can have different results on different trials")
     def test_multi_label_classification_keras(self):
         warnings.filterwarnings("ignore")

--- a/tests/integration_tests/pipeline_optimization/test_pipeline_optimization.py
+++ b/tests/integration_tests/pipeline_optimization/test_pipeline_optimization.py
@@ -95,14 +95,17 @@ class TestPipelineOptimization(TestCase):
             if file.endswith('.log'):
                 os.remove(file)
 
+        if os.path.exists('model'):
+            shutil.rmtree('model')
         # remove model directories (ending with _model)
         for file in os.listdir():
-            if file.endswith('_model'):
-                shutil.rmtree(file)
-            elif file.startswith('test_pipeline_'):
-                shutil.rmtree(file)
-            elif file.startswith('test_predictor_pipeline_'):
-                shutil.rmtree(file)
+            if not file.endswith('.py'):
+                if file.endswith('_model'):
+                    shutil.rmtree(file)
+                elif file.startswith('test_pipeline_'):
+                    shutil.rmtree(file)
+                elif file.startswith('test_predictor_pipeline_'):
+                    shutil.rmtree(file)
         # remove study rdbm
         try:
             optuna.delete_study(study_name="test_pipeline", storage="sqlite:///test_pipeline.db")


### PR DESCRIPTION
Some `categorical_choices` were poorly made. They worked but were not compatible with `optuna-dashboard`, for instance:

```python
agg_modes = trial.suggest_categorical('agg_modes', [['mean'], ['flatten']])
```
is now:

```python
agg_modes = trial.suggest_categorical('agg_modes', [str(cat) for cat in [['mean'], ['flatten']]])
agg_modes = eval(agg_modes)
```

Some minor changes in the names of the choices were also made.

The pipeline_optimization tests were run locally (the skip decorator was removed) and everything seems to be ok.