### PR TITLE
Migration from tensorflow 2.12.0 to 2.14.0 and some issues fixed in Pipeline Optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          - 3.8
+          - 3.9
 
     steps:
       - uses: actions/checkout@v3

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -21,7 +21,8 @@ scikeras==0.12.0: deep_learning
 dgllife==0.3.2: deep_learning
 deepchem==2.7.1: deep_learning
 torch_geometric==2.3.1: deep_learning
-tensorflow==2.15.0: deep_learning
+tensorflow==2.14.0: deep_learning
+nvidia-cudnn-cu11==8.6.0.163: deep_learning
 tensorflow-probability==0.23.0: deep_learning
 boruta==0.3: preprocessing
 scikit-learn==1.2.0: machine_learning, deep_learning

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -16,11 +16,12 @@ kaleido==0.2.1: machine_learning
 plotly==5.13.1: machine_learning
 chembl_structure_pipeline==1.1.0: preprocessing
 torch==2.0.1: deep_learning
-dgl==0.9.1: deep_learning
+dgl==1.1.3: deep_learning
+scikeras==0.12.0: deep_learning
 dgllife==0.3.2: deep_learning
 deepchem==2.7.1: deep_learning
 torch_geometric==2.3.1: deep_learning
-tensorflow==2.12.0: deep_learning
+tensorflow==2.15.0: deep_learning
 tensorflow-probability==0.20.1: deep_learning
 boruta==0.3: preprocessing
 scikit-learn==1.2.0: machine_learning, deep_learning

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -15,7 +15,7 @@ kneed==0.8.2: machine_learning
 kaleido==0.2.1: machine_learning
 plotly==5.13.1: machine_learning
 chembl_structure_pipeline==1.1.0: preprocessing
-torch==2.0.1: deep_learning
+torch==2.1.2: deep_learning
 dgl==1.1.3: deep_learning
 scikeras==0.12.0: deep_learning
 dgllife==0.3.2: deep_learning
@@ -23,7 +23,7 @@ deepchem==2.7.1: deep_learning
 torch_geometric==2.3.1: deep_learning
 tensorflow==2.14.0: deep_learning
 nvidia-cudnn-cu11==8.6.0.163: deep_learning
-tensorflow-probability==0.23.0: deep_learning
+tensorflow-probability==0.22.1: deep_learning
 boruta==0.3: preprocessing
 scikit-learn==1.2.0: machine_learning, deep_learning
 optuna==3.1.1: machine_learning, deep_learning

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -22,7 +22,7 @@ dgllife==0.3.2: deep_learning
 deepchem==2.7.1: deep_learning
 torch_geometric==2.3.1: deep_learning
 tensorflow==2.15.0: deep_learning
-tensorflow-probability==0.20.1: deep_learning
+tensorflow-probability==0.23.0: deep_learning
 boruta==0.3: preprocessing
 scikit-learn==1.2.0: machine_learning, deep_learning
 optuna==3.1.1: machine_learning, deep_learning

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -7,7 +7,7 @@ h5py==3.7.0: preprocessing, deep_learning, machine_learning, test
 cached_property==1.5.2: preprocessing, deep_learning, machine_learning, test
 numpy==1.23.5: preprocessing, deep_learning, machine_learning, test
 dill==0.3.6: preprocessing, deep_learning, machine_learning, test
-shap==0.41.0: deep_learning, machine_learning
+shap==0.44.0: deep_learning, machine_learning
 gensim==4.2.0: preprocessing
 imblearn: preprocessing
 umap-learn==0.5.1: machine_learning

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ joblib==1.1.1
 pillow==8.4.0
 h5py==3.7.0
 deepchem==2.7.1
-shap==0.41.0
+shap==0.44.0
 gensim==4.2.0
 mol2vec @ git+https://github.com/samoturk/mol2vec#egg=mol2vec
 boruta==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ numpy==1.23.5
 dgllife==0.3.2
 dill==0.3.6
 optuna==3.1.1
-tensorflow-probability==0.20.1
+tensorflow-probability==0.23.0
 torch_geometric==2.3.1
 scikit-multilearn==0.2.0
 timeout-decorator==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rdkit==2023.9.1
 smilespe==0.0.3
 seaborn==0.12.0
-torch==2.0.1
+torch==2.1.2
 dgl==1.1.3
 joblib==1.1.1
 pillow==8.4.0
@@ -11,7 +11,8 @@ shap==0.41.0
 gensim==4.2.0
 mol2vec @ git+https://github.com/samoturk/mol2vec#egg=mol2vec
 boruta==0.3
-tensorflow==2.15.0
+tensorflow==2.14.0
+nvidia-cudnn-cu11==8.6.0.163
 chembl_structure_pipeline==1.1.0
 scikit-learn==1.2.0
 imblearn
@@ -24,7 +25,7 @@ numpy==1.23.5
 dgllife==0.3.2
 dill==0.3.6
 optuna==3.1.1
-tensorflow-probability==0.23.0
+tensorflow-probability==0.22.1
 torch_geometric==2.3.1
 scikit-multilearn==0.2.0
 timeout-decorator==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ rdkit==2023.9.1
 smilespe==0.0.3
 seaborn==0.12.0
 torch==2.0.1
-dgl==0.9.1
+dgl==1.1.3
 joblib==1.1.1
 pillow==8.4.0
 h5py==3.7.0
@@ -11,7 +11,7 @@ shap==0.41.0
 gensim==4.2.0
 mol2vec @ git+https://github.com/samoturk/mol2vec#egg=mol2vec
 boruta==0.3
-tensorflow==2.12.0
+tensorflow==2.15.0
 chembl_structure_pipeline==1.1.0
 scikit-learn==1.2.0
 imblearn
@@ -28,3 +28,4 @@ tensorflow-probability==0.20.1
 torch_geometric==2.3.1
 scikit-multilearn==0.2.0
 timeout-decorator==0.5.0
+scikeras==0.12.0

--- a/src/deepmol/compound_featurization/base_featurizer.py
+++ b/src/deepmol/compound_featurization/base_featurizer.py
@@ -97,7 +97,7 @@ class MolecularFeaturizer(ABC, Transformer):
         features, remove_mols = zip(*features)
 
         remove_mols_list = np.array(remove_mols)
-        dataset.remove_elements(dataset.ids[remove_mols_list], inplace=True)
+        dataset.remove_elements(np.array(dataset.ids)[remove_mols_list], inplace=True)
 
         features = np.array(features)
         features = features[~remove_mols_list]

--- a/src/deepmol/compound_featurization/base_featurizer.py
+++ b/src/deepmol/compound_featurization/base_featurizer.py
@@ -91,7 +91,6 @@ class MolecularFeaturizer(ABC, Transformer):
           The input Dataset containing a featurized representation of the molecules in Dataset.X.
         """
         molecules = dataset.mols
-
         multiprocessing_cls = JoblibMultiprocessing(process=self._featurize_mol, n_jobs=self.n_jobs)
         features = multiprocessing_cls.run(molecules)
 

--- a/src/deepmol/compound_featurization/deepchem_featurizers.py
+++ b/src/deepmol/compound_featurization/deepchem_featurizers.py
@@ -10,6 +10,7 @@ from deepchem.feat.molecule_featurizers.mat_featurizer import MATEncoding
 from deepchem.trans import DAGTransformer as DAGTransformerDC
 from deepchem.utils import ConformerGenerator
 from rdkit.Chem import Mol
+from rdkit.Chem import rdFreeSASA
 
 from deepmol.base import Transformer
 from deepmol.compound_featurization import MolecularFeaturizer
@@ -61,6 +62,53 @@ class ConvMolFeat(MolecularFeaturizer):
         self.per_atom_fragmentation = per_atom_fragmentation
         self.feature_names = ['conv_mol_feat']
 
+    def get_atom_features(self, mol):
+        
+        three_d_structure = False
+        if mol.GetNumConformers() > 0:
+            radii1 = rdFreeSASA.classifyAtoms(mol)
+            rdFreeSASA.CalcSASA(mol, radii1)
+            three_d_structure = True
+
+        for atom in mol.GetAtoms():
+            is_aromatic = atom.GetIsAromatic()
+            explicit_valence = atom.GetExplicitValence()
+            formal_charge = atom.GetFormalCharge()
+            hybridization = atom.GetHybridization()
+            implicit_valence = atom.GetImplicitValence()
+            is_in_ring = atom.IsInRing()
+            mass = atom.GetMass()
+            num_explicit_hs = atom.GetNumExplicitHs()
+            num_implicit_hs = atom.GetNumImplicitHs()
+            atom_number = atom.GetAtomicNum()
+
+
+            properties = [("is_aromatic", is_aromatic),
+                                                ("explicit_valence", explicit_valence),
+                                                ("formal_charge", formal_charge),
+                                                ("hybridization", hybridization),
+                                                ("implicit_valence", implicit_valence),
+                                                ("is_in_ring", is_in_ring),
+                                                ("mass", mass),
+                                                ("num_explicit_hs", num_explicit_hs),
+                                                ("num_implicit_hs", num_implicit_hs),
+                                                ("atom_number", atom_number)]
+            if three_d_structure:
+                positions = mol.GetConformer().GetAtomPosition(atom.GetIdx())
+                x, y, z = positions.x, positions.y, positions.z
+                sasa = float(atom.GetProp("SASA"))
+
+                properties.extend([("x", x), ("y", y), ("z", z), ("sasa", sasa)])
+
+            for property_name, property_value in properties:
+                # Construct the property name
+                atom_property_name = f"atom {atom.GetIdx():08d} {property_name}"
+                
+                # Assign the property to the molecule
+                mol.SetDoubleProp(atom_property_name, property_value)
+        return mol, properties
+        
+
     def _featurize(self, mol: Mol) -> ConvMol:
         """
         Featurizes a single molecule.
@@ -76,6 +124,10 @@ class ConvMolFeat(MolecularFeaturizer):
             The ConvMol features of the molecule.
         """
         # featurization process using DeepChem ConvMolFeaturizer
+        mol, properties = self.get_atom_features(mol)
+
+        self.atom_properties = [name for name, _ in properties]
+
         feature = ConvMolFeaturizer(
             master_atom=self.master_atom,
             use_chirality=self.use_chirality,

--- a/src/deepmol/datasets/datasets.py
+++ b/src/deepmol/datasets/datasets.py
@@ -812,7 +812,7 @@ class SmilesDataset(Dataset):
             self.clear_cached_properties()
             return self
         else:
-            raise ValueError('The list of indexes is empty.')
+            return self
 
     @inplace_decorator
     def select_features_by_name(self, names: List[str]) -> None:

--- a/src/deepmol/feature_importance/_utils.py
+++ b/src/deepmol/feature_importance/_utils.py
@@ -93,6 +93,6 @@ def get_model_instance_from_explainer(explainer: str, model: Model) -> Union[Mod
                          'https://github.com/slundberg/shap/issues/1136 and '
                          'https://github.com/slundberg/shap/issues/1650')
     elif explainer == 'deep':
-        return model.model.model
+        return model.model.model(**model.builder_kwargs)
     else:
         return model.model.predict

--- a/src/deepmol/models/_utils.py
+++ b/src/deepmol/models/_utils.py
@@ -31,7 +31,7 @@ def save_to_disk(model: 'Model', filename: str, compress: int = 3):
         try:
             with open(filename, 'wb') as f:
                 pickle.dump(model, f, protocol=pickle.HIGHEST_PROTOCOL)
-        except (TypeError, AttributeError):
+        except (TypeError, AttributeError, ValueError):
             # dump with dill
             with open(filename, 'wb') as f:
                 dill.dump(model, f)

--- a/src/deepmol/models/_utils.py
+++ b/src/deepmol/models/_utils.py
@@ -131,9 +131,12 @@ def multi_label_binarize(y_pred_proba, threshold=0.5) -> np.ndarray:
         np.ndarray: Binary predictions with shape (n_samples, n_classes).
     """
     n_samples, n_classes = y_pred_proba.shape
-    y_pred = np.zeros((n_samples, n_classes))
-    for i in range(n_classes):
-        y_pred[:, i] = (y_pred_proba[:, i] >= threshold).astype(int)
+    y_pred = np.zeros((n_samples, ))
+    shape = y_pred_proba.shape
+    if len(shape) == 2 and shape[1] == 2:
+        y_pred = (y_pred_proba[:, 1] >= threshold).astype(int)
+    else:
+        y_pred = (y_pred_proba[:, 0] >= threshold).astype(int)
     return y_pred
 
 

--- a/src/deepmol/models/_utils.py
+++ b/src/deepmol/models/_utils.py
@@ -108,7 +108,7 @@ def _save_keras_model(file_path: str,
         file_path_model_builder = os.path.join(file_path, 'model_builder.pkl')
         save_to_disk(model_builder, file_path_model_builder)
     # write model in h5 format
-    model_file_path = os.path.join(file_path, 'model.h5')
+    model_file_path = os.path.join(file_path, 'model.keras')
     model.save(model_file_path)
     # write parameters in pickle format
     file_path_parameters = os.path.join(file_path, 'model_parameters.pkl')

--- a/src/deepmol/models/deepchem_model_builders.py
+++ b/src/deepmol/models/deepchem_model_builders.py
@@ -344,7 +344,7 @@ def progressive_multitask_classifier_model(progressive_multitask_classifier_kwar
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier
     # 1D Descriptors
-    model = ProgressiveMultitaskClassifier(**progressive_multitask_classifier_kwargs)
+    model = ProgressiveMultitaskClassifier
     return DeepChemModel(model=model, **deepchem_kwargs, **progressive_multitask_classifier_kwargs)
 
 

--- a/src/deepmol/models/deepchem_model_builders.py
+++ b/src/deepmol/models/deepchem_model_builders.py
@@ -6,7 +6,7 @@ from deepchem.models.chemnet_layers import Stem, InceptionResnetA, ReductionA, I
     InceptionResnetC
 from deepchem.models.layers import DTNNEmbedding, Highway, Stack, DAGLayer, DAGGather, WeaveLayer, WeaveGather
 from deepchem.models.torch_models import MATModel
-from keras.initializers.initializers import TruncatedNormal
+from keras.initializers import TruncatedNormal
 
 from deepmol.models import DeepChemModel
 
@@ -35,8 +35,8 @@ def gat_model(gat_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChem
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
-    model = GATModel(**gat_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = GATModel
+    return DeepChemModel(model=model, **deepchem_kwargs, **gat_kwargs)
 
 
 def gcn_model(gcn_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -62,8 +62,8 @@ def gcn_model(gcn_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChem
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
-    model = GCNModel(**gcn_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = GCNModel
+    return DeepChemModel(model=model, **deepchem_kwargs, **gcn_kwargs)
 
 
 def attentivefp_model(attentivefp_kwargs: dict = None,
@@ -92,8 +92,8 @@ def attentivefp_model(attentivefp_kwargs: dict = None,
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
-    model = AttentiveFPModel(**attentivefp_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = AttentiveFPModel
+    return DeepChemModel(model=model, **deepchem_kwargs, **attentivefp_kwargs)
 
 
 def pagtn_model(patgn_kwargs: dict = None,
@@ -120,8 +120,8 @@ def pagtn_model(patgn_kwargs: dict = None,
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # PagtnMolGraphFeaturizer MolGraphConvFeaturizer
-    model = PagtnModel(**patgn_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = PagtnModel
+    return DeepChemModel(model=model, **deepchem_kwargs, **patgn_kwargs)
 
 
 def mpnn_model(mpnn_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -148,8 +148,8 @@ def mpnn_model(mpnn_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepCh
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
-    model = MPNNModel(**mpnn_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = MPNNModel
+    return DeepChemModel(model=model, **deepchem_kwargs, **mpnn_kwargs)
 
 
 def megnet_model(megnet_kwargs: dict = None,
@@ -178,8 +178,8 @@ def megnet_model(megnet_kwargs: dict = None,
     megnet_kwargs = megnet_kwargs or {}
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
-    model = MEGNetModel(**megnet_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = MEGNetModel
+    return DeepChemModel(model=model, **deepchem_kwargs, **megnet_kwargs)
 
 
 def dmpnn_model(dmpnn_kwargs: dict = None,
@@ -206,8 +206,8 @@ def dmpnn_model(dmpnn_kwargs: dict = None,
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # DMPNNFeaturizer
-    model = DMPNNModel(**dmpnn_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = DMPNNModel
+    return DeepChemModel(model=model, **deepchem_kwargs, **dmpnn_kwargs)
 
 
 def cnn_model(cnn_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -231,8 +231,8 @@ def cnn_model(cnn_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChem
     cnn_kwargs = cnn_kwargs or {}
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
-    model = CNN(**cnn_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = CNN
+    return DeepChemModel(model=model, **deepchem_kwargs, **cnn_kwargs)
 
 
 def multitask_classifier_model(multitask_classifier_kwargs: dict = None,
@@ -258,10 +258,11 @@ def multitask_classifier_model(multitask_classifier_kwargs: dict = None,
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier
     # 1D Descriptors
-    model = MultitaskClassifier(**multitask_classifier_kwargs)
-    model.mode = 'classification'
-    model.model.mode = 'classification'
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = MultitaskClassifier
+    #TODO: check how we could workaround this
+    # model.mode = 'classification'
+    # model.model.mode = 'classification'
+    return DeepChemModel(model=model, **deepchem_kwargs, **multitask_classifier_kwargs)
 
 
 def multitask_irv_classifier_model(multitask_irv_classifier_kwargs: dict = None,
@@ -287,9 +288,10 @@ def multitask_irv_classifier_model(multitask_irv_classifier_kwargs: dict = None,
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier
     # 1D Descriptors
-    model = MultitaskIRVClassifier(**multitask_irv_classifier_kwargs)
-    model.model.mode = 'classification'
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = MultitaskIRVClassifier
+    #TODO: check how we could workaround this
+    # model.model.mode = 'classification'
+    return DeepChemModel(model=model, **deepchem_kwargs, **multitask_irv_classifier_kwargs)
 
 
 def progressive_multitask_classifier_model(progressive_multitask_classifier_kwargs: dict = None,
@@ -317,8 +319,9 @@ def progressive_multitask_classifier_model(progressive_multitask_classifier_kwar
     # Classifier
     # 1D Descriptors
     model = ProgressiveMultitaskClassifier(**progressive_multitask_classifier_kwargs)
-    model.model.mode = 'classification'
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    #TODO: check how we could workaround this
+    #model.model.mode = 'classification'
+    return DeepChemModel(model=model, **deepchem_kwargs, **progressive_multitask_classifier_kwargs)
 
 
 def progressive_multitask_regressor_model(progressive_multitask_regressor_kwargs: dict = None,
@@ -346,9 +349,10 @@ def progressive_multitask_regressor_model(progressive_multitask_regressor_kwargs
     # Regressor
     # CircularFingerprint RDKitDescriptors CoulombMatrixEig RdkitGridFeaturizer BindingPocketFeaturizer
     # ElementPropertyFingerprint
-    model = ProgressiveMultitaskRegressor(**progressive_multitask_regressor_kwargs)
-    model.model.mode = 'regression'
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = ProgressiveMultitaskRegressor
+    #TODO: check how we could workaround this
+    # model.model.mode = 'regression'
+    return DeepChemModel(model=model, **deepchem_kwargs, **progressive_multitask_regressor_kwargs)
 
 
 def robust_multitask_classifier_model(robust_multitask_classifier_kwargs: dict = None,
@@ -376,10 +380,11 @@ def robust_multitask_classifier_model(robust_multitask_classifier_kwargs: dict =
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier
     # 1D Descriptors
-    model = RobustMultitaskClassifier(**robust_multitask_classifier_kwargs)
-    model.model.mode = 'classification'
-    custom_objects = {'Stack': Stack}
-    return DeepChemModel(model=model, custom_objects=custom_objects, **deepchem_kwargs)
+    model = RobustMultitaskClassifier
+    #TODO: check how we could workaround this
+    # model.model.mode = 'classification'
+    # custom_objects = {'Stack': Stack}
+    return DeepChemModel(model=model, **deepchem_kwargs, **robust_multitask_classifier_kwargs)
 
 
 def robust_multitask_regressor_model(robust_multitask_regressor_kwargs: dict = None,
@@ -408,10 +413,11 @@ def robust_multitask_regressor_model(robust_multitask_regressor_kwargs: dict = N
     # Regressor
     # CircularFingerprint RDKitDescriptors CoulombMatrixEig RdkitGridFeaturizer BindingPocketFeaturizer
     # ElementPropertyFingerprint
-    model = RobustMultitaskRegressor(**robust_multitask_regressor_kwargs)
+    model = RobustMultitaskRegressor
+    #TODO: check how we could workaround this
     model.model.mode = 'regression'
     custom_objects = {'Stack': Stack}
-    return DeepChemModel(model=model, custom_objects=custom_objects, **deepchem_kwargs)
+    return DeepChemModel(model=model, custom_objects=custom_objects, **deepchem_kwargs, **robust_multitask_regressor_kwargs)
 
 
 def sc_score_model(sc_score_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -437,9 +443,10 @@ def sc_score_model(sc_score_kwargs: dict = None, deepchem_kwargs: dict = None) -
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier
     # CircularFingerprint
-    model = ScScoreModel(**sc_score_kwargs)
-    model.model.mode = 'classification'
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = ScScoreModel()
+    #TODO: check how we could workaround this
+    # model.model.mode = 'classification'
+    return DeepChemModel(model=model, **deepchem_kwargs, **sc_score_kwargs)
 
 
 def chem_ception_model(chem_ception_kwargs: dict = None,
@@ -467,11 +474,11 @@ def chem_ception_model(chem_ception_kwargs: dict = None,
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # SmilesToImage
-    model = ChemCeption(**chem_ception_kwargs)
-    custom_objects = {'Stem': Stem, 'InceptionResnetA': InceptionResnetA, 'ReductionA': ReductionA,
-                      'InceptionResnetB': InceptionResnetB, 'ReductionB': ReductionB,
-                      'InceptionResnetC': InceptionResnetC}
-    return DeepChemModel(model=model, custom_objects=custom_objects, **deepchem_kwargs)
+    model = ChemCeption
+    # custom_objects = {'Stem': Stem, 'InceptionResnetA': InceptionResnetA, 'ReductionA': ReductionA,
+    #                   'InceptionResnetB': InceptionResnetB, 'ReductionB': ReductionB,
+    #                   'InceptionResnetC': InceptionResnetC}
+    return DeepChemModel(model=model, **deepchem_kwargs, **chem_ception_kwargs)
 
 
 def dag_model(dag_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -499,9 +506,9 @@ def dag_model(dag_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChem
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # ConvMolFeaturizer
-    model = DAGModel(**dag_kwargs)
-    custom_objects = {'DAGLayer': DAGLayer, 'DAGGather': DAGGather}
-    return DeepChemModel(model=model, custom_objects=custom_objects, **deepchem_kwargs)
+    model = DAGModel
+    # custom_objects = {'DAGLayer': DAGLayer, 'DAGGather': DAGGather}
+    return DeepChemModel(model=model, **dag_kwargs, **deepchem_kwargs)
 
 
 def graph_conv_model(graph_conv_kwargs: dict = None,
@@ -529,8 +536,8 @@ def graph_conv_model(graph_conv_kwargs: dict = None,
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # ConvMolFeaturizer
-    model = GraphConvModel(**graph_conv_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = GraphConvModel
+    return DeepChemModel(model=model, **deepchem_kwargs, **graph_conv_kwargs)
 
 
 def smiles_to_vec_model(smiles_to_vec_kwargs: dict = None,
@@ -558,8 +565,8 @@ def smiles_to_vec_model(smiles_to_vec_kwargs: dict = None,
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # SmilesToSeq
-    model = Smiles2Vec(**smiles_to_vec_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = Smiles2Vec
+    return DeepChemModel(model=model, **deepchem_kwargs, **smiles_to_vec_kwargs)
 
 
 def text_cnn_model(text_cnn_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -586,9 +593,9 @@ def text_cnn_model(text_cnn_kwargs: dict = None, deepchem_kwargs: dict = None) -
     text_cnn_kwargs = text_cnn_kwargs or {}
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
-    model = TextCNNModel(**text_cnn_kwargs)
-    custom_objects = {"DTNNEmbedding": DTNNEmbedding, "Highway": Highway}
-    return DeepChemModel(model=model, custom_objects=custom_objects, **deepchem_kwargs)
+    model = TextCNNModel
+    # custom_objects = {"DTNNEmbedding": DTNNEmbedding, "Highway": Highway}
+    return DeepChemModel(model=model, **deepchem_kwargs, **text_cnn_kwargs)
 
 
 def weave_model(weave_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -615,9 +622,9 @@ def weave_model(weave_kwargs: dict = None, deepchem_kwargs: dict = None) -> Deep
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # WeaveFeaturizer
-    model = WeaveModel(**weave_kwargs)
-    custom_objects = {'WeaveLayer': WeaveLayer, 'TruncatedNormal': TruncatedNormal, 'WeaveGather': WeaveGather}
-    return DeepChemModel(model=model, custom_objects=custom_objects, **deepchem_kwargs)
+    model = WeaveModel
+    # custom_objects = {'WeaveLayer': WeaveLayer, 'TruncatedNormal': TruncatedNormal, 'WeaveGather': WeaveGather}
+    return DeepChemModel(model=model, **weave_kwargs, **deepchem_kwargs)
 
 
 def dtnn_model(dtnn_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -644,8 +651,8 @@ def dtnn_model(dtnn_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepCh
     deepchem_kwargs = deepchem_kwargs or {}
     # Regressor
     # CoulombMatrix
-    model = DTNNModel(**dtnn_kwargs)
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = DTNNModel
+    return DeepChemModel(model=model, **deepchem_kwargs, **dtnn_kwargs)
 
 
 def mat_model(mat_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -672,9 +679,9 @@ def mat_model(mat_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChem
     deepchem_kwargs = deepchem_kwargs or {}
     # Regressor
     # MATFeaturizer
-    model = MATModel(**mat_kwargs)
-    model.model.mode = 'regression'
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = MATModel
+    # model.model.mode = 'regression'
+    return DeepChemModel(model=model, **deepchem_kwargs, **mat_kwargs)
 
 
 def multitask_regressor_model(multitask_regressor_kwargs: dict = None,
@@ -700,7 +707,7 @@ def multitask_regressor_model(multitask_regressor_kwargs: dict = None,
     deepchem_kwargs = deepchem_kwargs or {}
     # Regressor
     # 1D Descriptors
-    model = MultitaskRegressor(**multitask_regressor_kwargs)
-    model.mode = 'regression'
-    model.model.mode = 'regression'
-    return DeepChemModel(model=model, **deepchem_kwargs)
+    model = MultitaskRegressor
+    # model.mode = 'regression'
+    # model.model.mode = 'regression'
+    return DeepChemModel(model=model, **deepchem_kwargs, **multitask_regressor_kwargs)

--- a/src/deepmol/models/deepchem_model_builders.py
+++ b/src/deepmol/models/deepchem_model_builders.py
@@ -2,13 +2,29 @@ from deepchem.models import GATModel, GCNModel, AttentiveFPModel, PagtnModel, MP
     MultitaskClassifier, MultitaskIRVClassifier, MultitaskRegressor, ProgressiveMultitaskClassifier, \
     ProgressiveMultitaskRegressor, RobustMultitaskClassifier, RobustMultitaskRegressor, ScScoreModel, \
     ChemCeption, DAGModel, GraphConvModel, Smiles2Vec, TextCNNModel, DTNNModel, WeaveModel
-from deepchem.models.chemnet_layers import Stem, InceptionResnetA, ReductionA, InceptionResnetB, ReductionB, \
-    InceptionResnetC
-from deepchem.models.layers import DTNNEmbedding, Highway, Stack, DAGLayer, DAGGather, WeaveLayer, WeaveGather
+# from deepchem.models.chemnet_layers import Stem, InceptionResnetA, ReductionA, InceptionResnetB, ReductionB, \
+#     InceptionResnetC
+# from deepchem.models.layers import DTNNEmbedding, Highway, Stack, DAGLayer, DAGGather, WeaveLayer, WeaveGather
 from deepchem.models.torch_models import MATModel
-from keras.initializers import TruncatedNormal
 
 from deepmol.models import DeepChemModel
+
+import dgl
+import torch as th
+from dgl import DGLError
+
+def check_if_cuda_is_available_for_dgl() -> bool:
+    """
+    Check if cuda is available for dgl.
+    """
+    
+    u, v = th.tensor([0, 1, 2]), th.tensor([2, 3, 4])
+    g = dgl.graph((u, v))
+    try:
+        g.to("cuda")
+        return True
+    except DGLError as e:
+        return False
 
 
 def gat_model(gat_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -35,7 +51,12 @@ def gat_model(gat_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChem
     deepchem_kwargs = deepchem_kwargs or {}
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
+
     model = GATModel
+    cuda_available = check_if_cuda_is_available_for_dgl()
+    if not cuda_available:
+        gat_kwargs["device"] = "cpu"
+
     return DeepChemModel(model=model, **deepchem_kwargs, **gat_kwargs)
 
 
@@ -63,6 +84,10 @@ def gcn_model(gcn_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChem
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
     model = GCNModel
+    cuda_available = check_if_cuda_is_available_for_dgl()
+    if not cuda_available:
+        gcn_kwargs["device"] = "cpu"
+
     return DeepChemModel(model=model, **deepchem_kwargs, **gcn_kwargs)
 
 
@@ -93,6 +118,9 @@ def attentivefp_model(attentivefp_kwargs: dict = None,
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
     model = AttentiveFPModel
+    cuda_available = check_if_cuda_is_available_for_dgl()
+    if not cuda_available:
+        attentivefp_kwargs["device"] = "cpu"
     return DeepChemModel(model=model, **deepchem_kwargs, **attentivefp_kwargs)
 
 
@@ -121,6 +149,9 @@ def pagtn_model(patgn_kwargs: dict = None,
     # Classifier/ Regressor
     # PagtnMolGraphFeaturizer MolGraphConvFeaturizer
     model = PagtnModel
+    cuda_available = check_if_cuda_is_available_for_dgl()
+    if not cuda_available:
+        patgn_kwargs["device"] = "cpu"
     return DeepChemModel(model=model, **deepchem_kwargs, **patgn_kwargs)
 
 
@@ -259,9 +290,6 @@ def multitask_classifier_model(multitask_classifier_kwargs: dict = None,
     # Classifier
     # 1D Descriptors
     model = MultitaskClassifier
-    #TODO: check how we could workaround this
-    # model.mode = 'classification'
-    # model.model.mode = 'classification'
     return DeepChemModel(model=model, **deepchem_kwargs, **multitask_classifier_kwargs)
 
 
@@ -289,8 +317,6 @@ def multitask_irv_classifier_model(multitask_irv_classifier_kwargs: dict = None,
     # Classifier
     # 1D Descriptors
     model = MultitaskIRVClassifier
-    #TODO: check how we could workaround this
-    # model.model.mode = 'classification'
     return DeepChemModel(model=model, **deepchem_kwargs, **multitask_irv_classifier_kwargs)
 
 
@@ -319,8 +345,6 @@ def progressive_multitask_classifier_model(progressive_multitask_classifier_kwar
     # Classifier
     # 1D Descriptors
     model = ProgressiveMultitaskClassifier(**progressive_multitask_classifier_kwargs)
-    #TODO: check how we could workaround this
-    #model.model.mode = 'classification'
     return DeepChemModel(model=model, **deepchem_kwargs, **progressive_multitask_classifier_kwargs)
 
 
@@ -350,8 +374,6 @@ def progressive_multitask_regressor_model(progressive_multitask_regressor_kwargs
     # CircularFingerprint RDKitDescriptors CoulombMatrixEig RdkitGridFeaturizer BindingPocketFeaturizer
     # ElementPropertyFingerprint
     model = ProgressiveMultitaskRegressor
-    #TODO: check how we could workaround this
-    # model.model.mode = 'regression'
     return DeepChemModel(model=model, **deepchem_kwargs, **progressive_multitask_regressor_kwargs)
 
 
@@ -381,8 +403,6 @@ def robust_multitask_classifier_model(robust_multitask_classifier_kwargs: dict =
     # Classifier
     # 1D Descriptors
     model = RobustMultitaskClassifier
-    #TODO: check how we could workaround this
-    # model.model.mode = 'classification'
     # custom_objects = {'Stack': Stack}
     return DeepChemModel(model=model, **deepchem_kwargs, **robust_multitask_classifier_kwargs)
 
@@ -414,10 +434,8 @@ def robust_multitask_regressor_model(robust_multitask_regressor_kwargs: dict = N
     # CircularFingerprint RDKitDescriptors CoulombMatrixEig RdkitGridFeaturizer BindingPocketFeaturizer
     # ElementPropertyFingerprint
     model = RobustMultitaskRegressor
-    #TODO: check how we could workaround this
-    model.model.mode = 'regression'
-    custom_objects = {'Stack': Stack}
-    return DeepChemModel(model=model, custom_objects=custom_objects, **deepchem_kwargs, **robust_multitask_regressor_kwargs)
+    # custom_objects = {'Stack': Stack}
+    return DeepChemModel(model=model, **deepchem_kwargs, **robust_multitask_regressor_kwargs)
 
 
 def sc_score_model(sc_score_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChemModel:
@@ -444,8 +462,6 @@ def sc_score_model(sc_score_kwargs: dict = None, deepchem_kwargs: dict = None) -
     # Classifier
     # CircularFingerprint
     model = ScScoreModel()
-    #TODO: check how we could workaround this
-    # model.model.mode = 'classification'
     return DeepChemModel(model=model, **deepchem_kwargs, **sc_score_kwargs)
 
 
@@ -680,7 +696,6 @@ def mat_model(mat_kwargs: dict = None, deepchem_kwargs: dict = None) -> DeepChem
     # Regressor
     # MATFeaturizer
     model = MATModel
-    # model.model.mode = 'regression'
     return DeepChemModel(model=model, **deepchem_kwargs, **mat_kwargs)
 
 
@@ -708,6 +723,4 @@ def multitask_regressor_model(multitask_regressor_kwargs: dict = None,
     # Regressor
     # 1D Descriptors
     model = MultitaskRegressor
-    # model.mode = 'regression'
-    # model.model.mode = 'regression'
     return DeepChemModel(model=model, **deepchem_kwargs, **multitask_regressor_kwargs)

--- a/src/deepmol/models/keras_model_builders.py
+++ b/src/deepmol/models/keras_model_builders.py
@@ -1,10 +1,11 @@
 from typing import List, Union, Tuple, Dict
 
-from tensorflow.keras import Sequential, regularizers, Model
+from tensorflow.keras import regularizers, Model
 from tensorflow.keras.layers import Dense, Dropout, BatchNormalization, GaussianNoise, Reshape, Conv1D, Flatten, \
     Embedding, MultiHeadAttention, LayerNormalization, Input, SimpleRNN, LSTM, GRU, Bidirectional
 
 from deepmol.models import KerasModel
+from keras.callbacks import EarlyStopping
 
 
 def keras_fcnn_model_builder(input_dim: int, n_tasks: int = 1, label_names: List[str] = None, n_hidden_layers: int = 1,

--- a/src/deepmol/models/keras_model_builders.py
+++ b/src/deepmol/models/keras_model_builders.py
@@ -5,7 +5,6 @@ from tensorflow.keras.layers import Dense, Dropout, BatchNormalization, Gaussian
     Embedding, MultiHeadAttention, LayerNormalization, Input, SimpleRNN, LSTM, GRU, Bidirectional
 
 from deepmol.models import KerasModel
-from keras.callbacks import EarlyStopping
 
 
 def keras_fcnn_model_builder(input_dim: int, n_tasks: int = 1, label_names: List[str] = None, n_hidden_layers: int = 1,

--- a/src/deepmol/models/keras_models.py
+++ b/src/deepmol/models/keras_models.py
@@ -57,6 +57,7 @@ class KerasModel(Model):
         self.epochs = epochs
         self.model_builder = model_builder
         self.verbose = verbose
+        self.builder_kwargs = kwargs
 
         self.fit_kwargs = {}
 
@@ -149,14 +150,12 @@ class KerasModel(Model):
             if "callbacks" not in kwargs and "callbacks" in self.fit_kwargs:
                 kwargs["callbacks"] = self.fit_kwargs["callbacks"]
 
-            self.model.fit(features, y, epochs=self.epochs, batch_size=self.batch_size, verbose=self.verbose,
-                                          **kwargs)
+            self.model.fit(features, y, epochs=self.epochs, batch_size=self.batch_size, verbose=self.verbose, **kwargs)
         
         if isinstance(self.model, KerasClassifier) or isinstance(self.model, KerasRegressor):
             self.history = self.model.history_
         else:
             self.history = self.model.history
-        
 
     def predict(self, dataset: Dataset) -> np.ndarray:
         """

--- a/src/deepmol/models/keras_models.py
+++ b/src/deepmol/models/keras_models.py
@@ -73,10 +73,10 @@ class KerasModel(Model):
                                    **kwargs}
 
         if mode == 'classification':
-            self.model = KerasClassifier(build_fn=model_builder, epochs=epochs, batch_size=batch_size,
+            self.model = KerasClassifier(model=model_builder, epochs=epochs, batch_size=batch_size,
                                          verbose=verbose, **kwargs)
         elif mode == 'regression':
-            self.model = KerasRegressor(build_fn=model_builder, epochs=epochs, batch_size=batch_size, verbose=verbose,
+            self.model = KerasRegressor(model=model_builder, epochs=epochs, batch_size=batch_size, verbose=verbose,
                                         **kwargs)
         elif isinstance(model_builder, keras.models.Model):
             self.model = model_builder

--- a/src/deepmol/models/keras_models.py
+++ b/src/deepmol/models/keras_models.py
@@ -58,6 +58,14 @@ class KerasModel(Model):
         self.model_builder = model_builder
         self.verbose = verbose
 
+        self.fit_kwargs = {}
+
+        if "validation_data" in kwargs and kwargs["validation_data"] is not None:
+            self.fit_kwargs = {"validation_data": kwargs.pop("validation_data")}
+
+        if "callbacks" in kwargs and kwargs["callbacks"] is not None:
+            self.fit_kwargs["callbacks"] = kwargs.pop("callbacks")
+
         self.parameters_to_save = {'mode': self.mode,
                                    'batch_size': self.batch_size,
                                    'epochs': self.epochs,
@@ -68,7 +76,7 @@ class KerasModel(Model):
             self.model = KerasClassifier(build_fn=model_builder, epochs=epochs, batch_size=batch_size,
                                          verbose=verbose, **kwargs)
         elif mode == 'regression':
-            self.model = KerasRegressor(build_fn=model_builder, nb_epoch=epochs, batch_size=batch_size, verbose=verbose,
+            self.model = KerasRegressor(build_fn=model_builder, epochs=epochs, batch_size=batch_size, verbose=verbose,
                                         **kwargs)
         elif isinstance(model_builder, keras.models.Model):
             self.model = model_builder
@@ -106,30 +114,48 @@ class KerasModel(Model):
         if len(dataset.label_names) == 1:
             y = np.squeeze(dataset.y)
 
-            if "validation_data" in kwargs:
-                validation_data = kwargs.pop("validation_data")
+            validation_data = kwargs.pop("validation_data", None)
+            
+            if validation_data is None:
+                validation_data = self.fit_kwargs.pop("validation_data", None)
+            
+            if validation_data is not None:
                 y_valid = np.squeeze(validation_data.y)
                 valid_features = validation_data.X.astype('float32')
                 validation_data = (valid_features, y_valid)
-                kwargs["validation_data"] = validation_data
+                
+            kwargs["validation_data"] = validation_data
+            if "callbacks" not in kwargs and "callbacks" in self.fit_kwargs:
+                kwargs["callbacks"] = self.fit_kwargs["callbacks"]
 
-            self.model = self.model.fit(features, y, **kwargs)
+            self.model.fit(features, y, **kwargs)
         else:
             targets = [dataset.y[:, i] for i in range(len(dataset.label_names))]
             y = {f"{dataset.label_names[i]}": targets[i] for i in range(len(dataset.label_names))}
 
-            if "validation_data" in kwargs:
-                validation_data = kwargs.pop("validation_data")
+            validation_data = kwargs.pop("validation_data", None)
+            
+            if validation_data is None:
+                validation_data = self.fit_kwargs.pop("validation_data", None)
+            
+            if validation_data is not None:
+                y_valid = np.squeeze(validation_data.y)
                 targets = [validation_data.y[:, i] for i in range(len(dataset.label_names))]
                 y_valid = {f"{dataset.label_names[i]}": targets[i] for i in range(len(dataset.label_names))}
                 valid_features = validation_data.X.astype('float32')
                 validation_data = (valid_features, y_valid)
-                kwargs["validation_data"] = validation_data
+                
+            kwargs["validation_data"] = validation_data
+            if "callbacks" not in kwargs and "callbacks" in self.fit_kwargs:
+                kwargs["callbacks"] = self.fit_kwargs["callbacks"]
 
-            self.model = self.model.fit(features, y, epochs=self.epochs, batch_size=self.batch_size, verbose=self.verbose,
+            self.model.fit(features, y, epochs=self.epochs, batch_size=self.batch_size, verbose=self.verbose,
                                           **kwargs)
-            
-        self.history = self.model.history_
+        
+        if isinstance(self.model, KerasClassifier) or isinstance(self.model, KerasRegressor):
+            self.history = self.model.history_
+        else:
+            self.history = self.model.history
         
 
     def predict(self, dataset: Dataset) -> np.ndarray:
@@ -165,13 +191,16 @@ class KerasModel(Model):
         np.ndarray
             predictions
         """
-        try:
-            predictions = self.model.predict_proba(dataset.X.astype('float32'))
-        except AttributeError as e:
-            self.logger.error(e)
-            self.logger.info(str(self.model))
-            self.logger.info(str(type(self.model)))
+        if self.model.__class__.__name__ == 'KerasRegressor':
             predictions = self.model.predict(dataset.X.astype('float32'))
+        else:
+            try:
+                predictions = self.model.predict_proba(dataset.X.astype('float32'))
+            except AttributeError as e:
+                self.logger.error(e)
+                self.logger.info(str(self.model))
+                self.logger.info(str(type(self.model)))
+                predictions = self.model.predict(dataset.X.astype('float32'))
 
         predictions = np.array(predictions)
         if predictions.shape != (len(dataset.mols), dataset.n_tasks):
@@ -226,7 +255,7 @@ class KerasModel(Model):
         """
         file_path_model_builder = os.path.join(folder_path, 'model_builder.pkl')
         model_builder = load_from_disk(file_path_model_builder)
-        file_path_model = os.path.join(folder_path, 'model.h5')
+        file_path_model = os.path.join(folder_path, 'model.keras')
         model_ = keras.models.load_model(file_path_model)
         model_parameters = load_from_disk(os.path.join(folder_path, 'model_parameters.pkl'))
         keras_model_class = cls(model_builder=model_builder, **model_parameters)
@@ -238,6 +267,21 @@ class KerasModel(Model):
         else:
             keras_model_class.model = model
         return keras_model_class
+    
+    def _save(self, file_path: str) -> None:
+        if isinstance(self.model, KerasClassifier) or isinstance(self.model, KerasRegressor):
+            try:
+                # write self in pickle format
+                _save_keras_model(file_path, self.model.model, self.parameters_to_save, self.model_builder)
+                save_to_disk(self.model, os.path.join(file_path, 'model.pkl'))
+            except AttributeError:
+                # write self in pickle format
+                _save_keras_model(file_path, self.model.model_, self.parameters_to_save, self.model_builder)
+                save_to_disk(self.model, os.path.join(file_path, 'model.pkl'))
+        else:
+            # write self in pickle format
+            _save_keras_model(file_path, self.model, self.parameters_to_save, self.model_builder)
+            save_to_disk(self.model, os.path.join(file_path, 'model.pkl'))
 
     def save(self, file_path: str = None) -> None:
         """
@@ -252,23 +296,9 @@ class KerasModel(Model):
             if self.model_dir is None:
                 raise ValueError('No model directory specified.')
             else:
-                try:
-                    # write self in pickle format
-                    _save_keras_model(self.model_dir, self.model.model, self.parameters_to_save, self.model_builder)
-                    save_to_disk(self.model, os.path.join(self.model_dir, 'model.pkl'))
-                except AttributeError:
-                    # write self in pickle format
-                    _save_keras_model(self.model_dir, self.model.model_, self.parameters_to_save, self.model_builder)
-                    save_to_disk(self.model, os.path.join(self.model_dir, 'model.pkl'))
+                self._save(self.model_dir)
         else:
-            try:
-                # write self in pickle format
-                _save_keras_model(file_path, self.model.model, self.parameters_to_save, self.model_builder)
-                save_to_disk(self.model, os.path.join(file_path, 'model.pkl'))
-            except AttributeError:
-                # write self in pickle format
-                _save_keras_model(file_path, self.model.model_, self.parameters_to_save, self.model_builder)
-                save_to_disk(self.model, os.path.join(file_path, 'model.pkl'))
+            self._save(file_path)
 
     def get_task_type(self) -> str:
         """

--- a/src/deepmol/parameter_optimization/hyperparameter_optimization.py
+++ b/src/deepmol/parameter_optimization/hyperparameter_optimization.py
@@ -171,9 +171,15 @@ class HyperparameterOptimizerCV(HyperparameterOptimizer):
                  maximize_metric: bool, n_iter_search: int = 15, n_jobs: int = 1, verbose: int = 0, logdir: str = None,
                  mode: str = None, cv=5, seed=123, refit=True, **kwargs):
 
+        if model_type == 'keras':
+            # get random values from the params_dict
+            # just to make sure that we instantiate the parameters in the keras model
+            keras_default_parameters = {k: [random.choice(v)] for k, v in params_dict.items()}
+            kwargs.update(keras_default_parameters)
+
         super().__init__(model_builder, model_type, params_dict, metric, maximize_metric, n_iter_search, n_jobs,
                          verbose, logdir, mode, **kwargs)
-
+        
         self.cv = cv
         self.seed = seed
         self.refit = refit

--- a/src/deepmol/parameter_optimization/hyperparameter_optimization.py
+++ b/src/deepmol/parameter_optimization/hyperparameter_optimization.py
@@ -8,7 +8,7 @@ from operator import mul
 from typing import Dict, Any, Tuple
 
 import numpy as np
-from keras.wrappers.scikit_learn import KerasRegressor, KerasClassifier
+from scikeras.wrappers import KerasRegressor, KerasClassifier
 from sklearn.metrics import make_scorer
 from sklearn.model_selection import StratifiedKFold, KFold, RandomizedSearchCV, GridSearchCV
 

--- a/src/deepmol/pipeline/__init__.py
+++ b/src/deepmol/pipeline/__init__.py
@@ -1,1 +1,2 @@
 from .pipeline import Pipeline
+from .ensemble import VotingPipeline

--- a/src/deepmol/pipeline/ensemble.py
+++ b/src/deepmol/pipeline/ensemble.py
@@ -142,7 +142,7 @@ class VotingPipeline:
         # [[0.1, 0.9], [0.8, 0.2]] -> [[[0.9, 0.1], [0.1, 0.9]], [[0.2, 0.8], [0.8, 0.2]]]
         preds = []
         for pipeline_predictions in predictions:
-            preds.append([[1 - prob, prob] for prob in pipeline_predictions])
+            preds.append([[1 - prob, prob] if isinstance(prob, float) else prob for prob in pipeline_predictions])
         # Calculate the weighted average of predicted probabilities
         soft_votes = np.average(preds, axis=0, weights=self.weights)
         # TODO: should this return classes or probabilities?

--- a/src/deepmol/pipeline/ensemble.py
+++ b/src/deepmol/pipeline/ensemble.py
@@ -282,7 +282,7 @@ class VotingPipeline:
         if not os.path.exists(path):
             os.makedirs(path)
         for pipeline in self.pipelines:
-            pipeline.path = os.path.join(path, pipeline.path)
+            pipeline.path = os.path.join(path, os.path.basename(os.path.normpath(pipeline.path)))
             pipeline.save()
         # save json with voting and weights info
         with open(os.path.join(path, 'voting_pipeline.json'), 'w') as f:

--- a/src/deepmol/pipeline/pipeline.py
+++ b/src/deepmol/pipeline/pipeline.py
@@ -136,7 +136,13 @@ class Pipeline(Transformer):
             if self.is_prediction_pipeline():
                 for name, transformer in self.steps[:-1]:
                     train_dataset = transformer.fit_transform(train_dataset)
-                self.steps[-1][1].fit(train_dataset)
+                    if validation_dataset is not None:
+                        validation_dataset = transformer.transform(validation_dataset)
+                
+                if validation_dataset is not None and self.steps[-1][1].__class__.__name__ == 'KerasModel':
+                    self.steps[-1][1].fit(train_dataset, validation_data = validation_dataset)
+                else:
+                    self.steps[-1][1].fit(train_dataset)
             else:
                 for name, transformer in self.steps:
                     train_dataset = transformer.fit_transform(train_dataset)
@@ -227,7 +233,7 @@ class Pipeline(Transformer):
 
     def evaluate(self,
                  dataset: Dataset,
-                 metrics: Union[List[Metric]],
+                 metrics: List[Metric],
                  per_task_metrics: bool = False) -> Tuple[Dict, Union[None, Dict]]:
         """
         Evaluate the pipeline on a dataset based on the provided metrics.

--- a/src/deepmol/pipeline_optimization/_deepchem_models_objectives.py
+++ b/src/deepmol/pipeline_optimization/_deepchem_models_objectives.py
@@ -31,9 +31,9 @@ def gat_model_steps(trial: Trial, gat_kwargs: dict = None,
     """
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
-    use_edges = trial.suggest_categorical('use_edges', [True, False])
-    use_chirality = trial.suggest_categorical('use_chirality', [True, False])
-    use_partial_charge = trial.suggest_categorical('use_partial_charge', [True, False])
+    use_edges = trial.suggest_categorical('use_edges_gat', [True, False])
+    use_chirality = trial.suggest_categorical('use_chirality_gat', [True, False])
+    use_partial_charge = trial.suggest_categorical('use_partial_charge_gat', [True, False])
     # get number of trues in the list
     n_features = 30
     if use_chirality:
@@ -48,9 +48,9 @@ def gat_model_steps(trial: Trial, gat_kwargs: dict = None,
     gat_kwargs['n_attention_heads'] = n_attention_heads
     agg_modes = trial.suggest_categorical('agg_modes', [['mean'], ['flatten']])
     gat_kwargs['agg_modes'] = agg_modes
-    dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropout = trial.suggest_float('dropout_gat', 0.0, 0.5, step=0.25)
     gat_kwargs['dropout'] = dropout
-    predictor_dropout = trial.suggest_float('predictor_dropout', 0.0, 0.5, step=0.25)
+    predictor_dropout = trial.suggest_float('predictor_dropout_gat', 0.0, 0.5, step=0.25)
     gat_kwargs['predictor_dropout'] = predictor_dropout
     model = gat_model(gat_kwargs=gat_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('featurizer', featurizer), ('model', model)]
@@ -78,9 +78,9 @@ def gcn_model_steps(trial: Trial, gcn_kwargs: dict = None,
     """
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
-    use_edges = trial.suggest_categorical('use_edges', [True, False])
-    use_chirality = trial.suggest_categorical('use_chirality', [True, False])
-    use_partial_charge = trial.suggest_categorical('use_partial_charge', [True, False])
+    use_edges = trial.suggest_categorical('use_edges_gcn', [True, False])
+    use_chirality = trial.suggest_categorical('use_chirality_gcn', [True, False])
+    use_partial_charge = trial.suggest_categorical('use_partial_charge_gcn', [True, False])
     # get number of trues in the list
     n_features = 30
     if use_chirality:
@@ -90,14 +90,14 @@ def gcn_model_steps(trial: Trial, gcn_kwargs: dict = None,
     gcn_kwargs['number_atom_features'] = n_features
     featurizer = MolGraphConvFeat(use_edges=use_edges, use_chirality=use_chirality, use_partial_charge=use_partial_charge)
     # model
-    graph_conv_layers = trial.suggest_categorical('graph_conv_layers',
+    graph_conv_layers = trial.suggest_categorical('graph_conv_layers_gcn',
                                                   [str(cat) for cat in [[32, 64], [64, 64], [64, 128]]])
     gcn_kwargs['graph_conv_layers'] = eval(graph_conv_layers)
     batchnorm = trial.suggest_categorical('batchnorm', [True, False])
     gcn_kwargs['batchnorm'] = batchnorm
-    dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropout = trial.suggest_float('dropout_gcn', 0.0, 0.5, step=0.25)
     gcn_kwargs['dropout'] = dropout
-    predictor_dropout = trial.suggest_float('predictor_dropout', 0.0, 0.5, step=0.25)
+    predictor_dropout = trial.suggest_float('predictor_dropout_gcn', 0.0, 0.5, step=0.25)
     gcn_kwargs['predictor_dropout'] = predictor_dropout
     model = gcn_model(gcn_kwargs=gcn_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('featurizer', featurizer), ('model', model)]
@@ -126,8 +126,8 @@ def attentive_fp_model_steps(trial: Trial, attentive_fp_kwargs: dict = None,
     """
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
-    use_chirality = trial.suggest_categorical('use_chirality', [True, False])
-    use_partial_charge = trial.suggest_categorical('use_partial_charge', [True, False])
+    use_chirality = trial.suggest_categorical('use_chirality_attentive_fp', [True, False])
+    use_partial_charge = trial.suggest_categorical('use_partial_charge_attentive_fp', [True, False])
     # get number of trues in the list
     n_features = 30
     if use_chirality:
@@ -137,11 +137,11 @@ def attentive_fp_model_steps(trial: Trial, attentive_fp_kwargs: dict = None,
     attentive_fp_kwargs['number_atom_features'] = n_features
     featurizer = MolGraphConvFeat(use_edges=True, use_chirality=use_chirality, use_partial_charge=use_partial_charge)
     # model
-    num_layers = trial.suggest_int('num_layers', 1, 5)
+    num_layers = trial.suggest_int('num_layers_attentive_fp', 1, 5)
     attentive_fp_kwargs['num_layers'] = num_layers
-    graph_feat_size = trial.suggest_int('graph_feat_size', 100, 500, step=100)
+    graph_feat_size = trial.suggest_int('graph_feat_size_attentive_fp', 100, 500, step=100)
     attentive_fp_kwargs['graph_feat_size'] = graph_feat_size
-    dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropout = trial.suggest_float('dropout_attentive_fp', 0.0, 0.5, step=0.25)
     attentive_fp_kwargs['dropout'] = dropout
     model = attentivefp_model( attentivefp_kwargs=attentive_fp_kwargs,
                               deepchem_kwargs=deepchem_kwargs)
@@ -170,7 +170,7 @@ def pagtn_model_steps(trial: Trial, pagtn_kwargs: dict = None,
     """
     # Classifier/ Regressor
     # PagtnMolGraphFeaturizer
-    max_length = trial.suggest_int('max_length', 5, 20)
+    max_length = trial.suggest_int('max_length_pagtn', 5, 20)
     featurizer = PagtnMolGraphFeat(max_length)
     feature = PagtnMolGraphFeaturizer(max_length=max_length).featurize([MolFromSmiles('CCC')])[0]
     node_features = feature.node_features.shape[1]
@@ -178,11 +178,11 @@ def pagtn_model_steps(trial: Trial, pagtn_kwargs: dict = None,
     # model
     pagtn_kwargs["number_atom_features"] = node_features
     pagtn_kwargs["number_bond_features"] = edge_features
-    num_layers = trial.suggest_int('num_layers', 2, 5)
+    num_layers = trial.suggest_int('num_layers_pagtn', 2, 5)
     pagtn_kwargs['num_layers'] = num_layers
     num_heads = trial.suggest_int('num_heads', 1, 2)
     pagtn_kwargs['num_heads'] = num_heads
-    dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropout = trial.suggest_float('dropout_pagtn', 0.0, 0.5, step=0.25)
     pagtn_kwargs['dropout'] = dropout
     model = pagtn_model(patgn_kwargs=pagtn_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('featurizer', featurizer), ('model', model)]
@@ -210,8 +210,8 @@ def mpnn_model_steps(trial: Trial, mpnn_kwargs: dict = None,
     """
     # Classifier/ Regressor
     # MolGraphConvFeaturizer
-    use_chirality = trial.suggest_categorical('use_chirality', [True, False])
-    use_partial_charge = trial.suggest_categorical('use_partial_charge', [True, False])
+    use_chirality = trial.suggest_categorical('use_chirality_mpnn', [True, False])
+    use_partial_charge = trial.suggest_categorical('use_partial_charge_mpnn', [True, False])
     # get number of trues in the list
     n_features = 30
     if use_chirality:
@@ -219,9 +219,9 @@ def mpnn_model_steps(trial: Trial, mpnn_kwargs: dict = None,
     if use_partial_charge:
         n_features += 1
     featurizer = MolGraphConvFeat(use_edges=True, use_chirality=use_chirality, use_partial_charge=use_partial_charge)
-    n_hidden = trial.suggest_int('n_hidden', 50, 250, step=50)
+    n_hidden = trial.suggest_int('n_hidden_mpnn', 50, 250, step=50)
     mpnn_kwargs['n_hidden'] = n_hidden
-    dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropout = trial.suggest_float('dropout_mpnn', 0.0, 0.5, step=0.25)
     mpnn_kwargs['dropout'] = dropout
     model = mpnn_model(mpnn_kwargs=mpnn_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('featurizer', featurizer), ('model', model)]
@@ -249,9 +249,9 @@ def megnet_model_steps(trial: Trial, megnet_kwargs: dict = None,
     """
     # Classifier/ Regressor
     # MolGraphConvFeat
-    use_edges = trial.suggest_categorical('use_edges', [True, False])
-    use_chirality = trial.suggest_categorical('use_chirality', [True, False])
-    use_partial_charge = trial.suggest_categorical('use_partial_charge', [True, False])
+    use_edges = trial.suggest_categorical('use_edges_megnet', [True, False])
+    use_chirality = trial.suggest_categorical('use_chirality_megnet', [True, False])
+    use_partial_charge = trial.suggest_categorical('use_partial_charge_megnet', [True, False])
     # get number of trues in the list
     n_features = 30
     if use_chirality:
@@ -294,7 +294,7 @@ def dmpnn_model_steps(trial: Trial, dmpnn_kwargs: dict = None,
     dmpnn_kwargs['fnn_layers'] = fnn_layers
     fnn_dropout_p = trial.suggest_float('fnn_dropout_p', 0.0, 0.5, step=0.25)
     dmpnn_kwargs['fnn_dropout_p'] = fnn_dropout_p
-    depth = trial.suggest_int('depth', 2, 4)
+    depth = trial.suggest_int('depth_dmpnn', 2, 4)
     dmpnn_kwargs['depth'] = depth
     model = dmpnn_model(dmpnn_kwargs=dmpnn_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('featurizer', featurizer), ('model', model)]
@@ -325,9 +325,9 @@ def cnn_model_steps(trial: Trial, cnn_kwargs: dict = None,
     layer_filters = trial.suggest_categorical('layer_filters',
                                               [str(cat) for cat in [[100], [100, 100], [100, 100, 100]]])
     cnn_kwargs['layer_filters'] = eval(layer_filters)
-    kernel_size = trial.suggest_int('kernel_size', 3, 6)
+    kernel_size = trial.suggest_int('kernel_size_cnn', 3, 6)
     cnn_kwargs['kernel_size'] = kernel_size
-    dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropouts = trial.suggest_float('dropout_cnn', 0.0, 0.5, step=0.25)
     cnn_kwargs['dropouts'] = dropouts
     model = cnn_model(cnn_kwargs=cnn_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('model', model)]
@@ -356,9 +356,9 @@ def multitask_classifier_model_steps(trial: Trial,
     """
     # Classifier
     # 1D descriptors
-    dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropouts = trial.suggest_float('dropout_multitask_classifier', 0.0, 0.5, step=0.25)
     multitask_classifier_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    layer_sizes = trial.suggest_categorical('layer_sizes_multitask_classifier_model', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
     multitask_classifier_kwargs['layer_sizes'] = eval(layer_sizes)
     model = multitask_classifier_model(multitask_classifier_kwargs=multitask_classifier_kwargs,
                                        deepchem_kwargs=deepchem_kwargs)
@@ -418,9 +418,9 @@ def progressive_multitask_classifier_model_steps(trial: Trial,
     """
     # Classifier
     # 1D Descriptors
-    dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropouts = trial.suggest_float('dropout_progressive_multitask', 0.0, 0.5, step=0.25)
     progressive_multitask_classifier_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    layer_sizes = trial.suggest_categorical('layer_sizes_progressive_multitask_classifier', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
     progressive_multitask_classifier_kwargs['layer_sizes'] = eval(layer_sizes)
     model = progressive_multitask_classifier_model(progressive_multitask_classifier_kwargs=progressive_multitask_classifier_kwargs,
                                                    deepchem_kwargs=deepchem_kwargs)
@@ -450,11 +450,11 @@ def robust_multitask_classifier_model_steps(trial: Trial,
     """
     # Classifier
     # 1D Descriptors
-    dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropouts = trial.suggest_float('dropout_robust_multitask_classifier', 0.0, 0.5, step=0.25)
     robust_multitask_classifier_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    layer_sizes = trial.suggest_categorical('layer_sizes_robust_multitask_classifier', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
     robust_multitask_classifier_kwargs['layer_sizes'] = eval(layer_sizes)
-    bypass_dropouts = trial.suggest_float('bypass_dropout', 0.0, 0.5, step=0.25)
+    bypass_dropouts = trial.suggest_float('bypass_dropout_robust_multitask_classifier', 0.0, 0.5, step=0.25)
     robust_multitask_classifier_kwargs['bypass_dropouts'] = bypass_dropouts
     model = robust_multitask_classifier_model(
                                               robust_multitask_classifier_kwargs=robust_multitask_classifier_kwargs,
@@ -484,9 +484,9 @@ def sc_score_model_steps(trial: Trial, sc_score_kwargs: dict = None,
     """
     # Classifier
     # 1D Descriptors
-    dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropouts = trial.suggest_float('dropout_sc_score', 0.0, 0.5, step=0.25)
     sc_score_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes',
+    layer_sizes = trial.suggest_categorical('layer_sizes_sc_score',
                                             [str(cat) for cat in [[100, 100, 100], [300, 300, 300], [500, 200, 100]]])
     sc_score_kwargs['layer_sizes'] = eval(layer_sizes)
     model = sc_score_model(sc_score_kwargs=sc_score_kwargs, deepchem_kwargs=deepchem_kwargs)
@@ -546,14 +546,14 @@ def dag_model_steps(trial: Trial, dag_kwargs: dict = None,
     # Classifier/ Regressor
     # ConvMolFeaturizer
     featurizer = ConvMolFeat()
-    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    layer_sizes = trial.suggest_categorical('layer_sizes_dag', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
     dag_kwargs['layer_sizes'] = eval(layer_sizes)
-    dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropout = trial.suggest_float('dropout_dag', 0.0, 0.5, step=0.25)
     dag_kwargs['dropout'] = dropout
     layer_sizes_gather = trial.suggest_categorical('layer_sizes_gather', 
                                                     [str(cat) for cat in [[50], [100], [500], [200, 100]]])
     dag_kwargs['layer_sizes_gather'] = eval(layer_sizes_gather)
-    n_graph_feat = trial.suggest_categorical('n_graph_feat', [30, 64, 128, 256])
+    n_graph_feat = trial.suggest_categorical('n_graph_feat_dag', [30, 64, 128, 256])
     dag_kwargs['n_graph_feat'] = n_graph_feat
 
     transformer = DagTransformer()
@@ -585,7 +585,7 @@ def graph_conv_model_steps(trial: Trial, graph_conv_kwargs: dict = None,
     # Classifier/ Regressor
     # ConvMolFeaturizer
     master_atom = trial.suggest_categorical('master_atom', [True, False])
-    use_chirality = trial.suggest_categorical('use_chirality', [True, False])
+    use_chirality = trial.suggest_categorical('use_chirality_graph_conv', [True, False])
 
     featurizer = ConvMolFeat(master_atom=master_atom, use_chirality=use_chirality)
     graph_conv_layers = trial.suggest_categorical('graph_conv_layers_conv_model',
@@ -594,7 +594,7 @@ def graph_conv_model_steps(trial: Trial, graph_conv_kwargs: dict = None,
     graph_conv_kwargs['graph_conv_layers'] = eval(graph_conv_layers)
     dense_layer_size = trial.suggest_categorical('dense_layer_size', [128, 256, 512])
     graph_conv_kwargs['dense_layer_size'] = dense_layer_size
-    dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropout = trial.suggest_float('dropout_graph_conv', 0.0, 0.5, step=0.25)
     graph_conv_kwargs['dropout'] = dropout
     model = graph_conv_model( graph_conv_kwargs=graph_conv_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('featurizer', featurizer), ('model', model)]
@@ -627,7 +627,7 @@ def smiles_to_vec_model_steps(trial: Trial, smiles_to_vec_kwargs: dict = None,
     smiles_to_vec_kwargs['embedding_dim'] = embedding_dim
     filters = trial.suggest_categorical('filters', [32, 64, 128])
     smiles_to_vec_kwargs['filters'] = filters
-    kernel_size = trial.suggest_categorical('kernel_size', [3, 5, 7])
+    kernel_size = trial.suggest_categorical('kernel_size_smiles_to_vec', [3, 5, 7])
     smiles_to_vec_kwargs['kernel_size'] = kernel_size
     strides = trial.suggest_categorical('strides', [1, 2, 3])
     smiles_to_vec_kwargs['strides'] = strides
@@ -657,9 +657,9 @@ def text_cnn_model_steps(trial: Trial, text_cnn_kwargs: dict = None,
         List of tuples (steps) with the model.
     """
     # Classifier/ Regressor
-    n_embedding = trial.suggest_categorical('n_embedding', [50, 75, 100])
+    n_embedding = trial.suggest_categorical('n_embedding_text_cnn', [50, 75, 100])
     text_cnn_kwargs['n_embedding'] = n_embedding
-    dropout = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropout = trial.suggest_float('dropout_text_cnn', 0.0, 0.5, step=0.25)
     text_cnn_kwargs['dropout'] = dropout
     model = text_cnn_model(text_cnn_kwargs=text_cnn_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('model', model)]
@@ -687,20 +687,20 @@ def weave_model_steps(trial: Trial, weave_kwargs: dict = None,
     """
     # Classifier/ Regressor
     # WeaveFeaturizer
-    use_chirality = trial.suggest_categorical('use_chirality', [True, False])
+    use_chirality = trial.suggest_categorical('use_chirality_weave', [True, False])
     if use_chirality:
         n_atom_feat = 78
         weave_kwargs['n_atom_feat'] = n_atom_feat
         weave_kwargs['n_pair_feat'] = 18
     
     featurizer = WeaveFeat(use_chirality=use_chirality)
-    n_hidden = trial.suggest_categorical('n_hidden', [50, 100, 200])
+    n_hidden = trial.suggest_categorical('n_hidden_weave', [50, 100, 200])
     weave_kwargs['n_hidden'] = n_hidden
-    n_graph_feat = trial.suggest_categorical('n_graph_feat', [64, 128, 256])
+    n_graph_feat = trial.suggest_categorical('n_graph_feat_weave', [64, 128, 256])
     weave_kwargs['n_graph_feat'] = n_graph_feat
     # n_weave = trial.suggest_categorical('n_weave', [1, 2, 3])
     # weave_kwargs['n_weave'] = n_weave
-    dropouts = trial.suggest_float('dropouts', 0.0, 0.5, step=0.25)
+    dropouts = trial.suggest_float('dropouts_weave', 0.0, 0.5, step=0.25)
     weave_kwargs['dropouts'] = dropouts
     model = weave_model(weave_kwargs=weave_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('featurizer', featurizer), ('model', model)]
@@ -728,11 +728,11 @@ def dtnn_model_steps(trial: Trial, dtnn_kwargs: dict = None,
     """
     # Regressor
     # CoulombMatrix
-    n_embedding = trial.suggest_categorical('n_embedding', [50, 75, 100])
+    n_embedding = trial.suggest_categorical('n_embedding_dtnn', [50, 75, 100])
     dtnn_kwargs['n_embedding'] = n_embedding
-    n_hidden = trial.suggest_categorical('n_hidden', [50, 100, 200])
+    n_hidden = trial.suggest_categorical('n_hidden_dtnn', [50, 100, 200])
     dtnn_kwargs['n_hidden'] = n_hidden
-    dropout = trial.suggest_float('dropouts', 0.0, 0.5, step=0.25)
+    dropout = trial.suggest_float('dropouts_dtnn', 0.0, 0.5, step=0.25)
     dtnn_kwargs['dropout'] = dropout
     model = dtnn_model(dtnn_kwargs=dtnn_kwargs, deepchem_kwargs=deepchem_kwargs)
     return [('model', model)]
@@ -804,9 +804,9 @@ def progressive_multitask_regressor_model_steps(trial: Trial,
     """
     # Regressor
     # 1D Descriptors
-    dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropouts = trial.suggest_float('dropout_progressive_multitask_regressor', 0.0, 0.5, step=0.25)
     progressive_multitask_regressor_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    layer_sizes = trial.suggest_categorical('layer_sizes_progressive_multitask_regressor', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
     progressive_multitask_regressor_kwargs['layer_sizes'] = eval(layer_sizes)
     model = progressive_multitask_regressor_model(progressive_multitask_regressor_kwargs=progressive_multitask_regressor_kwargs,
                                                   deepchem_kwargs=deepchem_kwargs)
@@ -836,9 +836,9 @@ def multitask_regressor_model_steps(trial: Trial,
     """
     # Regressor
     # 1D Descriptors
-    dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropouts = trial.suggest_float('dropout_multitask_regressor', 0.0, 0.5, step=0.25)
     multitask_regressor_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    layer_sizes = trial.suggest_categorical('layer_sizes_multitask_regressor', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
     multitask_regressor_kwargs['layer_sizes'] = eval(layer_sizes)
     model = multitask_regressor_model(multitask_regressor_kwargs=multitask_regressor_kwargs,
                                       deepchem_kwargs=deepchem_kwargs)
@@ -868,11 +868,11 @@ def robust_multitask_regressor_model_steps(trial: Trial,
     """
     # Regressor
     # 1D Descriptors
-    dropouts = trial.suggest_float('dropout', 0.0, 0.5, step=0.25)
+    dropouts = trial.suggest_float('dropout_robust_multitask_regressor', 0.0, 0.5, step=0.25)
     robust_multitask_regressor_kwargs['dropouts'] = dropouts
-    layer_sizes = trial.suggest_categorical('layer_sizes', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
+    layer_sizes = trial.suggest_categorical('layer_sizes_robust_multitask_regressor', [str(cat) for cat in [[50], [100], [500], [200, 100]]])
     robust_multitask_regressor_kwargs['layer_sizes'] = eval(layer_sizes)
-    bypass_dropouts = trial.suggest_float('bypass_dropout', 0.0, 0.5, step=0.25)
+    bypass_dropouts = trial.suggest_float('bypass_dropout_robust_multitask_regressor', 0.0, 0.5, step=0.25)
     robust_multitask_regressor_kwargs['bypass_dropouts'] = bypass_dropouts
     model = robust_multitask_regressor_model(robust_multitask_regressor_kwargs=robust_multitask_regressor_kwargs,
                                              deepchem_kwargs=deepchem_kwargs)

--- a/src/deepmol/pipeline_optimization/_keras_model_objectives.py
+++ b/src/deepmol/pipeline_optimization/_keras_model_objectives.py
@@ -53,8 +53,9 @@ def keras_fcnn_step(trial: Trial, input_shape: tuple, label_names: List[str] = N
                     'hidden_activations': hidden_activations, 'hidden_regularizers': l1_l2,
                     'hidden_dropouts': hidden_dropouts, 'batch_normalization': batch_normalization,
                     'last_layers_units': last_layers_units, 'last_layers_activations': last_layers_activations,
-                    'optimizer': 'adam', 'losses': losses, 'metrics': metrics}
-    keras_kwargs = {'mode': mode}
+                    'optimizer': 'adam', 'losses': losses, 'metrics': metrics, 'callbacks': [EarlyStopping(patience=10)]}
+    keras_kwargs = {'mode': mode, 'batch_size': trial.suggest_categorical('batch_size_fcnn', [16, 32, 64, 128, 256]),
+                    'epochs': trial.suggest_categorical('epochs_fcnn', [30, 50, 100, 150, 200, 300, 500, 1000])}
     return keras_fcnn_model(model_kwargs=model_kwargs, keras_kwargs=keras_kwargs)
 
 
@@ -108,8 +109,9 @@ def keras_1d_cnn_step(trial: Trial, input_shape: tuple, label_names: List[str] =
                     'conv_dropouts': conv_dropouts, 'conv_batch_norms': conv_batch_norms, 'dense_units': dense_units,
                     'dense_activation': dense_activation, 'dense_dropout': dense_dropout,
                     'last_layers_units': last_layers_units, 'last_layers_activations': last_layers_activations,
-                    'losses': losses, 'optimizer': 'adam', 'metrics': metrics}
-    keras_kwargs = {'mode': mode}
+                    'losses': losses, 'optimizer': 'adam', 'metrics': metrics, 'callbacks': [EarlyStopping(patience=10)]}
+    keras_kwargs = {'mode': mode, 'batch_size': trial.suggest_categorical('batch_size_1d_conv', [16, 32, 64, 128, 256]),
+                    'epochs': trial.suggest_categorical('epochs_1d_conv', [30, 50, 100, 150, 200, 300, 500, 1000])}
     return keras_1d_cnn_model(model_kwargs=model_kwargs, keras_kwargs=keras_kwargs)
 
 
@@ -160,8 +162,9 @@ def keras_tabular_transformer_step(trial: Trial, input_shape: tuple, label_names
                     'attention_key_dims': attention_key_dims, 'dense_units': dense_units,
                     'dense_activation': dense_activation, 'dense_dropout': dense_dropout, 'optimizer': 'adam',
                     'last_layers_units': last_layers_units, 'last_layers_activations': last_layers_activations,
-                    'losses': losses, 'metrics': metrics}
-    keras_kwargs = {'mode': mode}
+                    'losses': losses, 'metrics': metrics, 'callbacks': [EarlyStopping(patience=10)]}
+    keras_kwargs = {'mode': mode, 'batch_size': trial.suggest_categorical('batch_size_tabular_transformer', [16, 32, 64, 128, 256]),
+                    'epochs': trial.suggest_categorical('epochs_tabular_transformer', [30, 50, 100, 150, 200, 300, 500, 1000])}
     return keras_tabular_transformer_model(model_kwargs=model_kwargs, keras_kwargs=keras_kwargs)
 
 
@@ -208,8 +211,10 @@ def keras_simple_rnn_step(trial: Trial, input_shape: tuple, label_names: List[st
                     'n_rnn_layers': n_rnn_layers, 'rnn_units': rnn_units, 'rnn_dropouts': rnn_dropouts,
                     'dense_units': dense_units, 'dense_dropout': dense_dropout, 'dense_activation': dense_activation,
                     'optimizer': 'adam', 'last_layers_units': last_layers_units,
-                    'last_layers_activations': last_layers_activations, 'losses': losses, 'metrics': metrics}
-    keras_kwargs = {'mode': mode}
+                    'last_layers_activations': last_layers_activations, 'losses': losses, 'metrics': metrics,
+                    'callbacks': [EarlyStopping(patience=10)]}
+    keras_kwargs = {'mode': mode, 'batch_size': trial.suggest_categorical('batch_size_simple_rnn', [16, 32, 64, 128, 256]),
+                    'epochs': trial.suggest_categorical('epochs_simple_rnn', [30, 50, 100, 150, 200, 300, 500, 1000])}
     return keras_simple_rnn_model(model_kwargs=model_kwargs, keras_kwargs=keras_kwargs)
 
 
@@ -260,8 +265,10 @@ def keras_rnn_step(trial: Trial, input_shape: tuple, label_names: List[str] = No
                     'n_gru_layers': n_gru_layers, 'gru_units': gru_units, 'gru_dropout': gru_dropout,
                     'dense_units': dense_units, 'dense_dropout': dense_dropout, 'dense_activation': dense_activation,
                     'optimizer': 'adam', 'last_layers_units': last_layers_units,
-                    'last_layers_activations': last_layers_activations, 'losses': losses, 'metrics': metrics}
-    keras_kwargs = {'mode': mode}
+                    'last_layers_activations': last_layers_activations, 'losses': losses, 'metrics': metrics,
+                    'callbacks': [EarlyStopping(patience=10)]}
+    keras_kwargs = {'mode': mode, 'batch_size': trial.suggest_categorical('batch_size_rnn', [16, 32, 64, 128, 256]),
+                    'epochs': trial.suggest_categorical('epochs_rnn', [30, 50, 100, 150, 200, 300, 500, 1000])}
     return keras_rnn_model(model_kwargs=model_kwargs, keras_kwargs=keras_kwargs)
 
 
@@ -312,8 +319,10 @@ def keras_bidirectional_rnn_step(trial: Trial, input_shape: tuple, label_names: 
                     'n_gru_layers': n_gru_layers, 'gru_units': gru_units, 'gru_dropout': gru_dropout,
                     'dense_units': dense_units, 'dense_dropout': dense_dropout, 'dense_activation': dense_activation,
                     'optimizer': 'adam', 'last_layers_units': last_layers_units,
-                    'last_layers_activations': last_layers_activations, 'losses': losses, 'metrics': metrics}
-    keras_kwargs = {'mode': mode}
+                    'last_layers_activations': last_layers_activations, 'losses': losses, 'metrics': metrics,
+                    'callbacks': [EarlyStopping(patience=10)]}
+    keras_kwargs = {'mode': mode, 'batch_size': trial.suggest_categorical('batch_size_bi_rnn', [16, 32, 64, 128, 256]),
+                    'epochs': trial.suggest_categorical('epochs_bi_rnn', [30, 50, 100, 150, 200, 300, 500, 1000])}
     return keras_bidirectional_rnn_model(model_kwargs=model_kwargs, keras_kwargs=keras_kwargs)
 
 

--- a/src/deepmol/pipeline_optimization/_sklearn_model_objectives.py
+++ b/src/deepmol/pipeline_optimization/_sklearn_model_objectives.py
@@ -1,4 +1,5 @@
 from deepmol.base import Predictor
+from deepmol.datasets.datasets import Dataset
 from deepmol.models.sklearn_model_builders import *
 
 
@@ -33,7 +34,7 @@ def ridge_step(trial):
     Predictor
         The Ridge object step.
     """
-    alpha = trial.suggest_float('alpha', 0.001, 10.0)
+    alpha = trial.suggest_float('alpha_ridge_model', 0.001, 10.0)
     ridge_kwargs = {'alpha': alpha}
     return ridge_model(ridge_kwargs=ridge_kwargs)
 
@@ -52,7 +53,7 @@ def ridge_classifier_step(trial):
     Predictor
         The RidgeClassifier object step.
     """
-    alpha = trial.suggest_float('alpha', 0.001, 10.0)
+    alpha = trial.suggest_float('alpha_ridge_classifier', 0.001, 10.0)
     ridge_classifier_kwargs = {'alpha': alpha}
     return ridge_classifier_model(ridge_classifier_kwargs=ridge_classifier_kwargs)
 
@@ -71,7 +72,7 @@ def ridge_cv_step(trial):
     Predictor
         The RidgeCV object step.
     """
-    alpha = trial.suggest_float('alpha', 0.01, 10.0)
+    alpha = trial.suggest_float('alpha_ridge_cv', 0.01, 10.0)
     ridge_cv_kwargs = {'alphas': alpha}
     return ridge_cv_model(ridge_cv_kwargs=ridge_cv_kwargs)
 
@@ -90,7 +91,7 @@ def ridge_classifier_cv_step(trial):
     Predictor
         The RidgeClassifierCV object step.
     """
-    alpha = trial.suggest_float('alpha', 0.01, 10.0)
+    alpha = trial.suggest_float('alpha_ridge_classifier_cv', 0.01, 10.0)
     ridge_classifier_cv_kwargs = {'alphas': alpha}
     return ridge_classifier_cv_model(ridge_classifier_cv_kwargs=ridge_classifier_cv_kwargs)
 
@@ -109,7 +110,7 @@ def lasso_step(trial):
     Predictor
         The Lasso object step.
     """
-    alpha = trial.suggest_float('alpha', 0.01, 10.0)
+    alpha = trial.suggest_float('alpha_lasso', 0.01, 10.0)
     lasso_kwargs = {'alpha': alpha}
     return lasso_model(lasso_kwargs=lasso_kwargs)
 
@@ -128,7 +129,7 @@ def lasso_cv_step(trial):
     Predictor
         The LassoCV object step.
     """
-    alpha = trial.suggest_float('alpha', 0.01, 10.0)
+    alpha = trial.suggest_float('alpha_lasso_cv', 0.01, 10.0)
     lasso_cv_kwargs = {'alphas': [alpha]}
     return lasso_cv_model(lasso_cv_kwargs=lasso_cv_kwargs)
 
@@ -164,7 +165,7 @@ def lasso_lars_ic_step(trial):
     Predictor
         The LassoLarsIC object step.
     """
-    criterion = trial.suggest_categorical('criterion', ['aic', 'bic'])
+    criterion = trial.suggest_categorical('criterion_lasso_lars', ['aic', 'bic'])
     lasso_lars_ic_kwargs = {'criterion': criterion}
     return lasso_lars_ic_model(lasso_lars_ic_kwargs=lasso_lars_ic_kwargs)
 
@@ -183,8 +184,8 @@ def elastic_net_step(trial):
     ElasticNet
         The ElasticNet object step.
     """
-    alpha = trial.suggest_float('alpha', 0.01, 10.0)
-    l1_ratio = trial.suggest_uniform('l1_ratio', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_elastic_net', 0.01, 10.0)
+    l1_ratio = trial.suggest_uniform('l1_ratio_elastic_net', 0.0, 1.0)
     elastic_net_kwargs = {'alpha': alpha, 'l1_ratio': l1_ratio}
     return elastic_net_model(elastic_net_kwargs=elastic_net_kwargs)
 
@@ -220,9 +221,9 @@ def bayesian_ridge_step(trial):
     Predictor
         The BayesianRidge object step.
     """
-    alpha = trial.suggest_float('alpha', 1e-5, 1e+1)
-    lambda_1 = trial.suggest_float('lambda_1', 1e-5, 1e+1)
-    lambda_2 = trial.suggest_float('lambda_2', 1e-5, 1e+1)
+    alpha = trial.suggest_float('alpha_bayesian_ridge', 1e-5, 1e+1)
+    lambda_1 = trial.suggest_float('lambda_1_bayesian_ridge', 1e-5, 1e+1)
+    lambda_2 = trial.suggest_float('lambda_2_bayesian_ridge', 1e-5, 1e+1)
     bayesian_ridge_kwargs = {'alpha_1': alpha, 'alpha_2': alpha, 'lambda_1': lambda_1, 'lambda_2': lambda_2}
     return bayesian_ridge_model(bayesian_ridge_kwargs=bayesian_ridge_kwargs)
 
@@ -243,8 +244,8 @@ def ard_regression_step(trial):
     """
     alpha_1 = trial.suggest_loguniform('alpha_1', 1e-8, 1.0)
     alpha_2 = trial.suggest_loguniform('alpha_2', 1e-8, 1.0)
-    lambda_1 = trial.suggest_loguniform('lambda_1', 1e-8, 1.0)
-    lambda_2 = trial.suggest_loguniform('lambda_2', 1e-8, 1.0)
+    lambda_1 = trial.suggest_loguniform('lambda_1_ard_regression', 1e-8, 1.0)
+    lambda_2 = trial.suggest_loguniform('lambda_2_ard_regression', 1e-8, 1.0)
     threshold_lambda = trial.suggest_loguniform('threshold_lambda', 1e-8, 1.0)
     ard_regression_kwargs = {'alpha_1': alpha_1, 'alpha_2': alpha_2, 'lambda_1': lambda_1, 'lambda_2': lambda_2,
                              'threshold_lambda': threshold_lambda}
@@ -265,7 +266,7 @@ def logistic_regression_step(trial):
     Predictor
         The LogisticRegression object step.
     """
-    C = trial.suggest_float('C', 0.01, 10.0, log=True)
+    C = trial.suggest_float('C_logistic_regression', 0.01, 10.0, log=True)
     logistic_regression_kwargs = {'C': C}
     return logistic_regression_model(logistic_regression_kwargs=logistic_regression_kwargs)
 
@@ -284,8 +285,8 @@ def logistic_regression_multiclass_step(trial):
     Predictor
         The LogisticRegressionMulticlass object step.
     """
-    C = trial.suggest_float('C', 0.01, 10.0, log=True)
-    multiclass_type = trial.suggest_categorical('multiclass_type', ['ovr', 'multinomial'])
+    C = trial.suggest_float('C_logistic_regression_multiclass', 0.01, 10.0, log=True)
+    multiclass_type = trial.suggest_categorical('multiclass_type_logistic_regression_multiclass', ['ovr', 'multinomial'])
     logistic_regression_multiclass_kwargs = {'C': C, 'multi_class': multiclass_type}
     return logistic_regression_model(logistic_regression_kwargs=logistic_regression_multiclass_kwargs)
 
@@ -304,7 +305,7 @@ def logistic_regression_cv_step(trial):
     Predictor
         The LogisticRegressionCV object step.
     """
-    Cs = trial.suggest_int('Cs', 1, 10)
+    Cs = trial.suggest_int('Cs_logistic_regression_cv', 1, 10)
     logistic_regression_cv_kwargs = {'Cs': Cs}
     return logistic_regression_cv_model(logistic_regression_cv_kwargs=logistic_regression_cv_kwargs)
 
@@ -323,8 +324,8 @@ def logistic_regression_cv_multiclass_step(trial):
     Predictor
         The LogisticRegressionMulticlassCV object step.
     """
-    Cs = trial.suggest_int('Cs', 1, 10)
-    multiclass_type = trial.suggest_categorical('multiclass_type', ['ovr', 'multinomial'])
+    Cs = trial.suggest_int('Cs_logistic_regression_cv_multiclass', 1, 10)
+    multiclass_type = trial.suggest_categorical('multiclass_type_logistic_regression_cv_multiclass', ['ovr', 'multinomial'])
     logistic_regression_cv_multiclass_kwargs = {'Cs': Cs, 'multi_class': multiclass_type}
     return logistic_regression_cv_model(logistic_regression_cv_kwargs=logistic_regression_cv_multiclass_kwargs)
 
@@ -343,8 +344,8 @@ def tweedie_regressor_step(trial):
     Predictor
         The TweedieRegressor object step.
     """
-    power = trial.suggest_float('power', 0.0, 1.0)
-    alpha = trial.suggest_float('alpha', 0.0, 2.0)
+    power = trial.suggest_float('power_tweedie_regressor', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_tweedie_regressor', 0.0, 2.0)
     tweedie_regression_kwargs = {'power': power, 'alpha': alpha}
     return tweedie_regressor_model(tweedie_regressor_kwargs=tweedie_regression_kwargs)
 
@@ -363,7 +364,7 @@ def poisson_regressor_step(trial):
     Predictor
         The PoissonRegressor object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 2.0)
+    alpha = trial.suggest_float('alpha_poisson_regressor', 0.0, 2.0)
     poisson_regression_kwargs = {'alpha': alpha}
     return poisson_regressor_model(poisson_regressor_kwargs=poisson_regression_kwargs)
 
@@ -382,7 +383,7 @@ def gamma_regressor_step(trial):
     Predictor
         The GammaRegressor object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 2.0)
+    alpha = trial.suggest_float('alpha_gamma_regressor', 0.0, 2.0)
     gamma_regression_kwargs = {'alpha': alpha}
     return gamma_regressor_model(gamma_regressor_kwargs=gamma_regression_kwargs)
 
@@ -401,7 +402,7 @@ def perceptron_step(trial):
     Predictor
         The Perceptron object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 2.0)
+    alpha = trial.suggest_float('alpha_perceptron', 0.0, 2.0)
     perceptron_kwargs = {'alpha': alpha}
     return perceptron_model(perceptron_kwargs=perceptron_kwargs)
 
@@ -420,7 +421,7 @@ def passive_aggressive_regressor_step(trial):
     Predictor
         The PassiveAggressiveRegressor object step.
     """
-    C = trial.suggest_float('C', 0.0, 10.0)
+    C = trial.suggest_float('C_passive_aggressive_regressor', 0.0, 10.0)
     passive_aggressive_regressor_kwargs = {'C': C}
     return passive_aggressive_regressor_model(passive_aggressive_regressor_kwargs=passive_aggressive_regressor_kwargs)
 
@@ -439,7 +440,7 @@ def passive_aggressive_classifier_step(trial):
     Classifier
         The PassiveAggressiveClassifier object step.
     """
-    C = trial.suggest_float('C', 0.0, 10.0)
+    C = trial.suggest_float('C_passive_aggressive_classifier', 0.0, 10.0)
     passive_aggressive_classifier_kwargs = {'C': C}
     return passive_aggressive_classifier_model(
         passive_aggressive_classifier_kwargs=passive_aggressive_classifier_kwargs)
@@ -459,8 +460,8 @@ def huber_regressor_step(trial):
     Predictor
         The HuberRegressor object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 2.0)
-    epsilon = trial.suggest_float('epsilon', 1.0, 2.0)
+    alpha = trial.suggest_float('alpha_huber_regressor', 0.0, 2.0)
+    epsilon = trial.suggest_float('epsilon_huber_regressor', 1.0, 2.0)
     huber_regressor_kwargs = {'alpha': alpha, 'epsilon': epsilon}
     return huber_regressor_model(huber_regressor_kwargs=huber_regressor_kwargs)
 
@@ -479,7 +480,7 @@ def ransac_regressor_step(trial):
     Predictor
         The RANSACRegressor object step.
     """
-    base_estimator = trial.suggest_categorical('base_estimator', ['linear', 'ridge', 'lasso'])
+    base_estimator = trial.suggest_categorical('base_estimator_ransac_regressor', ['linear', 'ridge', 'lasso'])
     if base_estimator == 'linear':
         model = LinearRegression()
     elif base_estimator == 'ridge':
@@ -523,7 +524,7 @@ def quantile_regressor_step(trial):
     Predictor
         The QuantileRegressor object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_quantile_regressor', 0.0, 1.0)
     quantile = trial.suggest_uniform('quantile', 0.1, 0.9)
     quantile_regressor_kwargs = {'alpha': alpha, 'quantile': quantile}
     return quantile_regressor_model(quantile_regressor_kwargs=quantile_regressor_kwargs)
@@ -582,9 +583,9 @@ def kernel_ridge_step(trial):
     Predictor
         The KernelRidge object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 1.0)
-    kernel = trial.suggest_categorical('kernel', ['linear', 'poly', 'rbf'])
-    gamma = trial.suggest_float('gamma', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_kernel_ridge', 0.0, 1.0)
+    kernel = trial.suggest_categorical('kernel_ridge', ['linear', 'poly', 'rbf'])
+    gamma = trial.suggest_float('gamma_kernel_ridge', 0.0, 1.0)
     kernel_ridge_kwargs = {'alpha': alpha, 'kernel': kernel, 'gamma': gamma}
     return kernel_ridge_regressor_model(kernel_ridge_regressor_kwargs=kernel_ridge_kwargs)
 
@@ -603,10 +604,10 @@ def svc_step(trial):
     Classifier
         The SVC object step.
     """
-    C = trial.suggest_float('C', 0.1, 10.0)
-    kernel = trial.suggest_categorical('kernel', ['linear', 'poly', 'rbf'])
-    gamma = trial.suggest_float('gamma', 0.0, 1.0)
-    degree = trial.suggest_int('degree', 2, 5)
+    C = trial.suggest_float('C_svc', 0.1, 10.0)
+    kernel = trial.suggest_categorical('kernel_svc', ['linear', 'poly', 'rbf'])
+    gamma = trial.suggest_float('gamma_svc', 0.0, 1.0)
+    degree = trial.suggest_int('degree_svc', 2, 5)
     svc_kwargs = {'C': C, 'kernel': kernel, 'gamma': gamma, 'degree': degree}
     return svc_model(svc_kwargs=svc_kwargs)
 
@@ -625,10 +626,10 @@ def nu_svc_step(trial):
     Classifier
         The NuSVC object step.
     """
-    nu = trial.suggest_float('nu', 0.0, 1.0)
-    kernel = trial.suggest_categorical('kernel', ['linear', 'poly', 'rbf'])
-    gamma = trial.suggest_float('gamma', 0.0, 1.0)
-    degree = trial.suggest_int('degree', 2, 5)
+    nu = trial.suggest_float('nu_nu_svc', 0.0, 1.0)
+    kernel = trial.suggest_categorical('kernel_nu_svc', ['linear', 'poly', 'rbf'])
+    gamma = trial.suggest_float('gamma_nu_svc', 0.0, 1.0)
+    degree = trial.suggest_int('degree_nu_svc', 2, 5)
     nu_svc_kwargs = {'nu': nu, 'kernel': kernel, 'gamma': gamma, 'degree': degree}
     return nu_svc_model(nu_svc_kwargs=nu_svc_kwargs)
 
@@ -647,7 +648,7 @@ def linear_svc_step(trial):
     Classifier
         The LinearSVC object step.
     """
-    C = trial.suggest_float('C', 0.1, 10.0)
+    C = trial.suggest_float('C_linear_svc', 0.1, 10.0)
     linear_svc_kwargs = {'C': C}
     return linear_svc_model(linear_svc_kwargs=linear_svc_kwargs)
 
@@ -666,8 +667,8 @@ def linear_svc_multiclass_step(trial):
     Classifier
         The LinearSVC object step.
     """
-    C = trial.suggest_float('C', 0.1, 10.0)
-    multiclass_type = trial.suggest_categorical('multiclass_type', ['ovr', 'crammer_singer'])
+    C = trial.suggest_float('C_linear_svc_multiclass', 0.1, 10.0)
+    multiclass_type = trial.suggest_categorical('multiclass_type_linear_svc_multiclass', ['ovr', 'crammer_singer'])
     linear_svc_multiclass_kwargs = {'C': C, 'multi_class': multiclass_type}
     return linear_svc_model(linear_svc_kwargs=linear_svc_multiclass_kwargs)
 
@@ -686,10 +687,10 @@ def svr_step(trial):
     Predictor
         The SVR object step.
     """
-    C = trial.suggest_float('C', 0.1, 10.0)
-    kernel = trial.suggest_categorical('kernel', ['linear', 'poly', 'rbf'])
-    gamma = trial.suggest_float('gamma', 0.0, 1.0)
-    degree = trial.suggest_int('degree', 2, 5)
+    C = trial.suggest_float('C_svr', 0.1, 10.0)
+    kernel = trial.suggest_categorical('kernel_svr', ['linear', 'poly', 'rbf'])
+    gamma = trial.suggest_float('gamma_svr', 0.0, 1.0)
+    degree = trial.suggest_int('degree_svr', 2, 5)
     svr_kwargs = {'C': C, 'kernel': kernel, 'gamma': gamma, 'degree': degree}
     return svr_model(svr_kwargs=svr_kwargs)
 
@@ -708,11 +709,11 @@ def nu_svr_step(trial):
     Predictor
         The NuSVR object step.
     """
-    nu = trial.suggest_float('nu', 0.0, 1.0)
-    C = trial.suggest_float('C', 0.1, 10.0)
-    kernel = trial.suggest_categorical('kernel', ['linear', 'poly', 'rbf'])
-    gamma = trial.suggest_float('gamma', 0.0, 1.0)
-    degree = trial.suggest_int('degree', 2, 5)
+    nu = trial.suggest_float('nu_nu_svr', 0.0, 1.0)
+    C = trial.suggest_float('C_nu_svr', 0.1, 10.0)
+    kernel = trial.suggest_categorical('kernel_nu_svr', ['linear', 'poly', 'rbf'])
+    gamma = trial.suggest_float('gamma_nu_svr', 0.0, 1.0)
+    degree = trial.suggest_int('degree_nu_svr', 2, 5)
     nu_svr_kwargs = {'nu': nu, 'kernel': kernel, 'gamma': gamma, 'degree': degree, 'C': C}
     return nu_svr_model(nu_svr_kwargs=nu_svr_kwargs)
 
@@ -731,8 +732,8 @@ def linear_svr_step(trial):
     Predictor
         The LinearSVR object step.
     """
-    epsilon = trial.suggest_float('epsilon', 0.0, 1.0)
-    C = trial.suggest_float('C', 0.1, 10.0)
+    epsilon = trial.suggest_float('epsilon_linear_svr', 0.0, 1.0)
+    C = trial.suggest_float('C_linear_svr', 0.1, 10.0)
     linear_svr_kwargs = {'epsilon': epsilon, 'C': C}
     return linear_svr_model(linear_svr_kwargs=linear_svr_kwargs)
 
@@ -751,10 +752,10 @@ def one_class_svm_step(trial):
     Predictor
         The OneClassSVM object step.
     """
-    nu = trial.suggest_float('nu', 0.0, 1.0)
-    kernel = trial.suggest_categorical('kernel', ['linear', 'poly', 'rbf'])
-    gamma = trial.suggest_float('gamma', 0.0, 1.0)
-    degree = trial.suggest_int('degree', 2, 5)
+    nu = trial.suggest_float('nu_one_class_svm', 0.0, 1.0)
+    kernel = trial.suggest_categorical('kernel_one_class_svm', ['linear', 'poly', 'rbf'])
+    gamma = trial.suggest_float('gamma_one_class_svm', 0.0, 1.0)
+    degree = trial.suggest_int('degree_one_class_svm', 2, 5)
     one_class_svm_kwargs = {'nu': nu, 'kernel': kernel, 'gamma': gamma, 'degree': degree}
     return one_class_svm_model(one_class_svm_kwargs=one_class_svm_kwargs)
 
@@ -774,9 +775,9 @@ def sgd_regressor_step(trial):
         The SGDRegressor object step.
     """
     penalty = trial.suggest_categorical('penalty', ['l2', 'l1', 'elasticnet'])
-    alpha = trial.suggest_float('alpha', 0.0, 1.0)
-    l1_ratio = trial.suggest_float('l1_ratio', 0.0, 1.0)
-    epsilon = trial.suggest_float('epsilon', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_sgd_regressor', 0.0, 1.0)
+    l1_ratio = trial.suggest_float('l1_ratio_sgd_regressor', 0.0, 1.0)
+    epsilon = trial.suggest_float('epsilon_sgd_regressor', 0.0, 1.0)
     sgd_regressor_kwargs = {'penalty': penalty, 'alpha': alpha, 'l1_ratio': l1_ratio, 'epsilon': epsilon}
     return sgd_regressor_model(sgd_regressor_kwargs=sgd_regressor_kwargs)
 
@@ -796,9 +797,9 @@ def sgd_classifier_step(trial):
         The SGDClassifier object step.
     """
     penalty = trial.suggest_categorical('penalty', ['l2', 'l1', 'elasticnet'])
-    alpha = trial.suggest_float('alpha', 0.0, 1.0)
-    l1_ratio = trial.suggest_float('l1_ratio', 0.0, 1.0)
-    epsilon = trial.suggest_float('epsilon', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_sgd_classifier', 0.0, 1.0)
+    l1_ratio = trial.suggest_float('l1_ratio_sgd_classifier', 0.0, 1.0)
+    epsilon = trial.suggest_float('epsilon_sgd_classifier', 0.0, 1.0)
     sgd_classifier_kwargs = {'penalty': penalty, 'alpha': alpha, 'l1_ratio': l1_ratio, 'epsilon': epsilon}
     return sgd_classifier_model(sgd_classifier_kwargs=sgd_classifier_kwargs)
 
@@ -817,7 +818,7 @@ def sgd_one_class_svm_step(trial):
     OneClassSVM
         The SGDOneClassSVM object step.
     """
-    nu = trial.suggest_float('nu', 0.0, 1.0)
+    nu = trial.suggest_float('nu_sgd_one_class_svm', 0.0, 1.0)
     tol = trial.suggest_float('tol', 0.0, 1.0)
     sgd_one_class_svm_kwargs = {'nu': nu, 'tol': tol}
     return sgd_one_class_svm_model(sgd_one_class_svm_kwargs=sgd_one_class_svm_kwargs)
@@ -837,10 +838,10 @@ def kneighbors_regressor_step(trial):
     Predictor
         The KNeighborsRegressor object step.
     """
-    n_neighbors = trial.suggest_int('n_neighbors', 2, 10)
-    weights = trial.suggest_categorical('weights', ['uniform', 'distance'])
-    algorithm = trial.suggest_categorical('algorithm', ['auto', 'ball_tree', 'kd_tree', 'brute'])
-    leaf_size = trial.suggest_int('leaf_size', 2, 10)
+    n_neighbors = trial.suggest_int('n_neighbors_kneighbors_regressor', 2, 10)
+    weights = trial.suggest_categorical('weights_kneighbors_regressor', ['uniform', 'distance'])
+    algorithm = trial.suggest_categorical('algorithm_kneighbors_regressor', ['auto', 'ball_tree', 'kd_tree', 'brute'])
+    leaf_size = trial.suggest_int('leaf_size_kneighbors_regressor', 2, 10)
     p = trial.suggest_int('p', 2, 10)
     kneighbors_regressor_kwargs = {'n_neighbors': n_neighbors, 'weights': weights, 'algorithm': algorithm,
                                    'leaf_size': leaf_size, 'p': p}
@@ -861,10 +862,10 @@ def kneighbors_classifier_step(trial):
     Classifier
         The KNeighborsClassifier object step.
     """
-    n_neighbors = trial.suggest_int('n_neighbors', 2, 10)
-    weights = trial.suggest_categorical('weights', ['uniform', 'distance'])
-    algorithm = trial.suggest_categorical('algorithm', ['auto', 'ball_tree', 'kd_tree', 'brute'])
-    leaf_size = trial.suggest_int('leaf_size', 2, 10)
+    n_neighbors = trial.suggest_int('n_neighbors_kneighbors_classifier', 2, 10)
+    weights = trial.suggest_categorical('weights_kneighbors_classifier', ['uniform', 'distance'])
+    algorithm = trial.suggest_categorical('algorithm_kneighbors_classifier', ['auto', 'ball_tree', 'kd_tree', 'brute'])
+    leaf_size = trial.suggest_int('leaf_size_kneighbors_classifier', 2, 10)
     p = trial.suggest_int('p', 2, 10)
     kneighbors_classifier_kwargs = {'n_neighbors': n_neighbors, 'weights': weights, 'algorithm': algorithm,
                                     'leaf_size': leaf_size, 'p': p}
@@ -885,10 +886,10 @@ def radius_neighbors_regressor_step(trial):
     Predictor
         The RadiusNeighborsRegressor object step.
     """
-    radius_n = trial.suggest_float('radius_n', 0.0, 10.0)
-    weights = trial.suggest_categorical('weights', ['uniform', 'distance'])
-    algorithm = trial.suggest_categorical('algorithm', ['auto', 'ball_tree', 'kd_tree', 'brute'])
-    leaf_size = trial.suggest_int('leaf_size', 2, 10)
+    radius_n = trial.suggest_float('radius_n_radius_neighbors_regressor', 0.0, 10.0)
+    weights = trial.suggest_categorical('weights_radius_neighbors_regressor', ['uniform', 'distance'])
+    algorithm = trial.suggest_categorical('algorithm_radius_neighbors_regressor', ['auto', 'ball_tree', 'kd_tree', 'brute'])
+    leaf_size = trial.suggest_int('leaf_size_radius_neighbors_regressor', 2, 10)
     p = trial.suggest_int('p', 2, 10)
     radius_neighbors_regressor_kwargs = {'radius': radius_n, 'weights': weights, 'algorithm': algorithm,
                                          'leaf_size': leaf_size, 'p': p}
@@ -909,10 +910,10 @@ def radius_neighbors_classifier_step(trial):
     Classifier
         The RadiusNeighborsClassifier object step.
     """
-    radius_n = trial.suggest_int('radius_n', 0.0, 10.0)
-    weights = trial.suggest_categorical('weights', ['uniform', 'distance'])
-    algorithm = trial.suggest_categorical('algorithm', ['auto', 'ball_tree', 'kd_tree', 'brute'])
-    leaf_size = trial.suggest_int('leaf_size', 2, 10)
+    radius_n = trial.suggest_int('radius_n_radius_neighbors_classifier', 0.0, 10.0)
+    weights = trial.suggest_categorical('weights_radius_neighbors_classifier', ['uniform', 'distance'])
+    algorithm = trial.suggest_categorical('algorithm_radius_neighbors_classifier', ['auto', 'ball_tree', 'kd_tree', 'brute'])
+    leaf_size = trial.suggest_int('leaf_size_radius_neighbors_classifier', 2, 10)
     p = trial.suggest_int('p', 2, 10)
     radius_neighbors_classifier_kwargs = {'radius': radius_n, 'weights': weights, 'algorithm': algorithm,
                                           'leaf_size': leaf_size, 'p': p}
@@ -952,7 +953,7 @@ def gaussian_process_regressor_step(trial):
     Predictor
         The GaussianProcessRegressor object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_gaussian_process_regressor', 0.0, 1.0)
     gaussian_process_regressor_kwargs = {'alpha': alpha}
     return gaussian_process_regressor_model(gaussian_process_regressor_kwargs=gaussian_process_regressor_kwargs)
 
@@ -971,7 +972,7 @@ def gaussian_process_multiclass_classifier_step(trial):
     Classifier
         The GaussianProcessClassifier object step.
     """
-    multiclass_type = trial.suggest_categorical('multiclass_type', ['one_vs_rest', 'one_vs_one'])
+    multiclass_type = trial.suggest_categorical('multiclass_type_gaussian_process_multiclass', ['one_vs_rest', 'one_vs_one'])
     gaussian_process_multiclass_classifier_kwargs = {'multi_class': multiclass_type}
     return gaussian_process_classifier_model(
         gaussian_process_classifier_kwargs=gaussian_process_multiclass_classifier_kwargs)
@@ -1047,7 +1048,7 @@ def multinomial_nb_step(trial):
     Classifier
         The MultinomialNB object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_multinomial_nb', 0.0, 1.0)
     multinomial_nb_kwargs = {'alpha': alpha}
     return multinomial_nb_model(multinomial_nb_kwargs=multinomial_nb_kwargs)
 
@@ -1066,7 +1067,7 @@ def bernoulli_nb_step(trial):
     Classifier
         The BernoulliNB object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_bernoulli_nb', 0.0, 1.0)
     bernoulli_nb_kwargs = {'alpha': alpha}
     return bernoulli_nb_model(bernoulli_nb_kwargs=bernoulli_nb_kwargs)
 
@@ -1085,7 +1086,7 @@ def categorical_nb_step(trial):
     Classifier
         The CategoricalNB object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_categorical_nb', 0.0, 1.0)
     categorical_nb_kwargs = {'alpha': alpha}
     return categorical_nb_model(categorical_nb_kwargs=categorical_nb_kwargs)
 
@@ -1104,7 +1105,7 @@ def complement_nb_step(trial):
     Classifier
         The ComplementNB object step.
     """
-    alpha = trial.suggest_float('alpha', 0.0, 1.0)
+    alpha = trial.suggest_float('alpha_complement_nb', 0.0, 1.0)
     complement_nb_kwargs = {'alpha': alpha}
     return complement_nb_model(complement_nb_kwargs=complement_nb_kwargs)
 
@@ -1141,7 +1142,7 @@ def decision_tree_classifier_step(trial):
     Classifier
         The DecisionTreeClassifier object step.
     """
-    criterion = trial.suggest_categorical('criterion', ['gini', 'entropy'])
+    criterion = trial.suggest_categorical('criterion_decision_tree', ['gini', 'entropy'])
     decision_tree_classifier_kwargs = {'criterion': criterion}
     return decision_tree_classifier_model(decision_tree_classifier_kwargs=decision_tree_classifier_kwargs)
 
@@ -1160,7 +1161,7 @@ def extra_tree_classifier_step(trial):
     Classifier
         The ExtraTreeClassifier object step.
     """
-    criterion = trial.suggest_categorical('criterion', ['gini', 'entropy'])
+    criterion = trial.suggest_categorical('criterion_extra_tree', ['gini', 'entropy'])
     extra_tree_classifier_kwargs = {'criterion': criterion}
     return extra_tree_classifier_model(extra_tree_classifier_kwargs=extra_tree_classifier_kwargs)
 
@@ -1197,10 +1198,10 @@ def random_forest_regressor_step(trial):
     Predictor
         The RandomForestRegressor object step.
     """
-    n_estimators = trial.suggest_int('n_estimators', 100, 1000, step=100)
-    criterion = trial.suggest_categorical('criterion', ['mse', 'mae'])
-    max_features = trial.suggest_categorical('max_features', ['auto', 'sqrt', 'log2'])
-    bootstrap = trial.suggest_categorical('bootstrap', [True, False])
+    n_estimators = trial.suggest_int('n_estimators_random_forest_regressor', 100, 1000, step=100)
+    criterion = trial.suggest_categorical('criterion_random_forest_regressor', ['squared_error', 'absolute_error', 'poisson', 'friedman_mse'])
+    max_features = trial.suggest_categorical('max_features_random_forest_regressor', ['auto', 'sqrt', 'log2'])
+    bootstrap = trial.suggest_categorical('bootstrap_random_forest_regressor', [True, False])
     random_forest_regressor_kwargs = {'n_estimators': n_estimators, 'criterion': criterion,
                                       'max_features': max_features, 'bootstrap': bootstrap}
     return random_forest_regressor_model(random_forest_regressor_kwargs=random_forest_regressor_kwargs)
@@ -1220,10 +1221,10 @@ def random_forest_classifier_step(trial):
     Classifier
         The RandomForestClassifier object step.
     """
-    n_estimators = trial.suggest_int('n_estimators', 100, 1000, step=100)
-    criterion = trial.suggest_categorical('criterion', ['gini', 'entropy'])
-    max_features = trial.suggest_categorical('max_features', ['auto', 'sqrt', 'log2'])
-    bootstrap = trial.suggest_categorical('bootstrap', [True, False])
+    n_estimators = trial.suggest_int('n_estimators_random_forest_classifier', 100, 1000, step=100)
+    criterion = trial.suggest_categorical('criterion_random_forest_classifier', ['gini', 'entropy'])
+    max_features = trial.suggest_categorical('max_features_random_forest_classifier', ['auto', 'sqrt', 'log2'])
+    bootstrap = trial.suggest_categorical('bootstrap_random_forest_classifier', [True, False])
     random_forest_classifier_kwargs = {'n_estimators': n_estimators, 'criterion': criterion,
                                        'max_features': max_features, 'bootstrap': bootstrap}
     return random_forest_classifier_model(random_forest_classifier_kwargs=random_forest_classifier_kwargs)
@@ -1243,10 +1244,10 @@ def extra_trees_regressor_step(trial):
     Predictor
         The ExtraTreesRegressor object step.
     """
-    n_estimators = trial.suggest_int('n_estimators', 100, 1000, step=100)
-    criterion = trial.suggest_categorical('criterion', ['mse', 'mae'])
-    max_features = trial.suggest_categorical('max_features', ['auto', 'sqrt', 'log2'])
-    bootstrap = trial.suggest_categorical('bootstrap', [True, False])
+    n_estimators = trial.suggest_int('n_estimators_extra_trees_regressor', 100, 1000, step=100)
+    criterion = trial.suggest_categorical('criterion_extra_trees_regressor', ['friedman_mse', 'squared_error', 'absolute_error', 'poisson'])
+    max_features = trial.suggest_categorical('max_features_extra_trees_regressor', ['auto', 'sqrt', 'log2'])
+    bootstrap = trial.suggest_categorical('bootstrap_extra_trees_regressor', [True, False])
     extra_trees_regressor_kwargs = {'n_estimators': n_estimators, 'criterion': criterion,
                                     'max_features': max_features, 'bootstrap': bootstrap}
     return extra_trees_regressor_model(extra_trees_regressor_kwargs=extra_trees_regressor_kwargs)
@@ -1266,10 +1267,10 @@ def extra_trees_classifier_step(trial):
     Classifier
         The ExtraTreesClassifier object step.
     """
-    n_estimators = trial.suggest_int('n_estimators', 100, 1000, step=100)
-    criterion = trial.suggest_categorical('criterion', ['gini', 'entropy'])
-    max_features = trial.suggest_categorical('max_features', ['auto', 'sqrt', 'log2'])
-    bootstrap = trial.suggest_categorical('bootstrap', [True, False])
+    n_estimators = trial.suggest_int('n_estimators_extra_trees_classifier', 100, 1000, step=100)
+    criterion = trial.suggest_categorical('criterion_extra_trees_classifier', ['gini', 'entropy'])
+    max_features = trial.suggest_categorical('max_features_extra_trees_classifier', ['auto', 'sqrt', 'log2'])
+    bootstrap = trial.suggest_categorical('bootstrap_extra_trees_classifier', [True, False])
     extra_trees_classifier_kwargs = {'n_estimators': n_estimators, 'criterion': criterion,
                                      'max_features': max_features, 'bootstrap': bootstrap}
     return extra_trees_classifier_model(extra_trees_classifier_kwargs=extra_trees_classifier_kwargs)
@@ -1289,9 +1290,9 @@ def ada_boost_regressor_step(trial):
     Predictor
         The AdaBoostRegressor object step.
     """
-    n_estimators = trial.suggest_int('n_estimators', 50, 500, step=50)
-    learning_rate = trial.suggest_float('learning_rate', 0.01, 1.0)
-    loss = trial.suggest_categorical('loss', ['linear', 'square', 'exponential'])
+    n_estimators = trial.suggest_int('n_estimators_ada_boost_regressor', 50, 500, step=50)
+    learning_rate = trial.suggest_float('learning_rate_ada_boost_regressor', 0.01, 1.0)
+    loss = trial.suggest_categorical('loss_ada_boost_regressor', ['linear', 'square', 'exponential'])
     ada_boost_regressor_kwargs = {'n_estimators': n_estimators, 'learning_rate': learning_rate, 'loss': loss}
     return ada_boost_regressor_model(ada_boost_regressor_kwargs=ada_boost_regressor_kwargs)
 
@@ -1310,9 +1311,9 @@ def ada_boost_classifier_step(trial):
     Classifier
         The AdaBoostClassifier object step.
     """
-    n_estimators = trial.suggest_int('n_estimators', 50, 500, step=50)
-    learning_rate = trial.suggest_float('learning_rate', 0.01, 1.0)
-    algorithm = trial.suggest_categorical('algorithm', ['SAMME', 'SAMME.R'])
+    n_estimators = trial.suggest_int('n_estimators_ada_boost_classifier', 50, 500, step=50)
+    learning_rate = trial.suggest_float('learning_rate_ada_boost_classifier', 0.01, 1.0)
+    algorithm = trial.suggest_categorical('algorithm_ada_boost_classifier', ['SAMME', 'SAMME.R'])
     ada_boost_classifier_kwargs = {'n_estimators': n_estimators, 'learning_rate': learning_rate,
                                    'algorithm': algorithm}
     return ada_boost_classifier_model(ada_boost_classifier_kwargs=ada_boost_classifier_kwargs)
@@ -1332,11 +1333,11 @@ def gradient_boosting_regressor_step(trial):
     Predictor
         The GradientBoostingRegressor object step.
     """
-    loss = trial.suggest_categorical('loss', ['ls', 'lad', 'huber', 'quantile'])
-    n_estimators = trial.suggest_int('n_estimators', 50, 500, step=50)
-    learning_rate = trial.suggest_float('learning_rate', 0.01, 1.0)
-    criterion = trial.suggest_categorical('criterion', ['friedman_mse', 'squared_error'])
-    max_features = trial.suggest_categorical('max_features', ['auto', 'sqrt', 'log2'])
+    loss = trial.suggest_categorical('loss_gradient_boosting_regressor', ['ls', 'lad', 'huber'])
+    n_estimators = trial.suggest_int('n_estimators_gradient_boosting_regressor', 50, 500, step=50)
+    learning_rate = trial.suggest_float('learning_rate_gradient_boosting_regressor', 0.01, 1.0)
+    criterion = trial.suggest_categorical('criterion_gradient_boosting_regressor', ['friedman_mse', 'squared_error'])
+    max_features = trial.suggest_categorical('max_features_gradient_boosting_regressor', ['auto', 'sqrt', 'log2'])
     gradient_boosting_regressor_kwargs = {'loss': loss, 'n_estimators': n_estimators,
                                           'learning_rate': learning_rate, 'criterion': criterion,
                                           'max_features': max_features}
@@ -1357,11 +1358,11 @@ def gradient_boosting_classifier_step(trial):
     Classifier
         The GradientBoostingClassifier object step.
     """
-    loss = trial.suggest_categorical('loss', ['deviance', 'exponential'])
-    n_estimators = trial.suggest_int('n_estimators', 50, 500, step=50)
-    learning_rate = trial.suggest_float('learning_rate', 0.01, 1.0)
-    criterion = trial.suggest_categorical('criterion', ['friedman_mse', 'mse'])
-    max_features = trial.suggest_categorical('max_features', ['auto', 'sqrt', 'log2'])
+    loss = trial.suggest_categorical('loss_gradient_boosting_classifier', ['deviance', 'exponential'])
+    n_estimators = trial.suggest_int('n_estimators_gradient_boosting_classifier', 50, 500, step=50)
+    learning_rate = trial.suggest_float('learning_rate_gradient_boosting_classifier', 0.01, 1.0)
+    criterion = trial.suggest_categorical('criterion_gradient_boosting_classifier', ['friedman_mse', 'squared_error'])
+    max_features = trial.suggest_categorical('max_features_gradient_boosting_classifier', ['auto', 'sqrt', 'log2'])
     gradient_boosting_classifier_kwargs = {'loss': loss, 'n_estimators': n_estimators,
                                            'learning_rate': learning_rate, 'criterion': criterion,
                                            'max_features': max_features}
@@ -1382,11 +1383,11 @@ def gradient_boosting_multiclass_classifier_step(trial):
     Classifier
         The GradientBoostingClassifier object step.
     """
-    loss = trial.suggest_categorical('loss', ['deviance', 'log_loss'])
-    n_estimators = trial.suggest_int('n_estimators', 50, 500, step=50)
-    learning_rate = trial.suggest_float('learning_rate', 0.01, 1.0)
-    criterion = trial.suggest_categorical('criterion', ['friedman_mse', 'mse'])
-    max_features = trial.suggest_categorical('max_features', ['auto', 'sqrt', 'log2'])
+    loss = trial.suggest_categorical('loss_gradient_boosting_multiclass_classifier', ['deviance', 'log_loss'])
+    n_estimators = trial.suggest_int('n_estimators_gradient_boosting_multiclass_classifier', 50, 500, step=50)
+    learning_rate = trial.suggest_float('learning_rate_gradient_boosting_multiclass_classifier', 0.01, 1.0)
+    criterion = trial.suggest_categorical('criterion_gradient_boosting_multiclass', ['friedman_mse', 'squared_error'])
+    max_features = trial.suggest_categorical('max_features_gradient_boosting_multiclass_classifier', ['auto', 'sqrt', 'log2'])
     gradient_boosting_classifier_kwargs = {'loss': loss, 'n_estimators': n_estimators,
                                            'learning_rate': learning_rate, 'criterion': criterion,
                                            'max_features': max_features}
@@ -1407,8 +1408,8 @@ def hist_gradient_boosting_regressor_step(trial):
     Predictor
         The HistGradientBoostingRegressor object step.
     """
-    loss = trial.suggest_categorical('loss', ['least_squares', 'least_absolute_deviation', 'poisson'])
-    learning_rate = trial.suggest_float('learning_rate', 0.01, 1.0)
+    loss = trial.suggest_categorical('loss_hist_gradient_boosting_regressor', ['poisson', 'absolute_error', 'squared_error'])
+    learning_rate = trial.suggest_float('learning_rate_hist_gradient_boosting_regressor', 0.01, 1.0)
     hist_gradient_boosting_regressor_kwargs = {'loss': loss, 'learning_rate': learning_rate}
     return hist_gradient_boosting_regressor_model(
         hist_gradient_boosting_regressor_kwargs=hist_gradient_boosting_regressor_kwargs)
@@ -1428,7 +1429,7 @@ def hist_gradient_boosting_classifier_step(trial):
     Classifier
         The HistGradientBoostingClassifier object step.
     """
-    learning_rate = trial.suggest_float('learning_rate', 0.01, 1.0)
+    learning_rate = trial.suggest_float('learning_rate_hist_gradient_boosting_classifier', 0.01, 1.0)
     hist_gradient_boosting_classifier_kwargs = {'learning_rate': learning_rate}
     return hist_gradient_boosting_classifier_model(
         hist_gradient_boosting_classifier_kwargs=hist_gradient_boosting_classifier_kwargs)
@@ -1540,7 +1541,7 @@ def bagging_regressor_step(trial):
     Predictor
         The BaggingRegressor object step.
     """
-    base_estimator = trial.suggest_categorical('base_estimator', ['lr', 'svr', 'rfr', 'gbr', 'mlpr'])
+    base_estimator = trial.suggest_categorical('base_estimator_bagging_regressor', ['lr', 'svr', 'rfr', 'gbr', 'mlpr'])
     if base_estimator == 'lr':
         base_estimator = LinearRegression()
     elif base_estimator == 'svr':
@@ -1551,8 +1552,8 @@ def bagging_regressor_step(trial):
         base_estimator = GradientBoostingRegressor()
     else:
         base_estimator = MLPRegressor()
-    n_estimators = trial.suggest_int('n_estimators', 50, 500, step=50)
-    bootstrap = trial.suggest_categorical('bootstrap', [True, False])
+    n_estimators = trial.suggest_int('n_estimators_bagging_regressor', 50, 500, step=50)
+    bootstrap = trial.suggest_categorical('bootstrap_bagging_regressor', [True, False])
     bootstrap_features = trial.suggest_categorical('bootstrap_features', [True, False])
     bagging_regressor_kwargs = {'base_estimator': base_estimator, 'n_estimators': n_estimators,
                                 'bootstrap': bootstrap, 'bootstrap_features': bootstrap_features}
@@ -1573,7 +1574,7 @@ def bagging_classifier_step(trial):
     Classifier
         The BaggingClassifier object step.
     """
-    base_estimator = trial.suggest_categorical('base_estimator', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
+    base_estimator = trial.suggest_categorical('base_estimator_bagging_classifier', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
     if base_estimator == 'lr':
         base_estimator = LogisticRegression()
     elif base_estimator == 'svc':
@@ -1584,8 +1585,8 @@ def bagging_classifier_step(trial):
         base_estimator = GradientBoostingClassifier()
     else:
         base_estimator = MLPClassifier()
-    n_estimators = trial.suggest_int('n_estimators', 50, 500, step=50)
-    bootstrap = trial.suggest_categorical('bootstrap', [True, False])
+    n_estimators = trial.suggest_int('n_estimators_bagging_classifier', 50, 500, step=50)
+    bootstrap = trial.suggest_categorical('bootstrap_bagging_classifier', [True, False])
     bootstrap_features = trial.suggest_categorical('bootstrap_features', [True, False])
     bagging_classifier_kwargs = {'base_estimator': base_estimator, 'n_estimators': n_estimators,
                                  'bootstrap': bootstrap, 'bootstrap_features': bootstrap_features}
@@ -1606,7 +1607,7 @@ def one_vs_rest_classifier_step(trial):
     Classifier
         The OneVsRestClassifier object step.
     """
-    estimator = trial.suggest_categorical('estimator', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
+    estimator = trial.suggest_categorical('estimator_one_vs_rest_classifier', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
     if estimator == 'lr':
         estimator = LogisticRegression()
     elif estimator == 'svc':
@@ -1635,7 +1636,7 @@ def one_vs_one_classifier_step(trial):
     Classifier
         The OneVsOneClassifier object step.
     """
-    estimator = trial.suggest_categorical('estimator', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
+    estimator = trial.suggest_categorical('estimator_one_vs_one_classifier', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
     if estimator == 'lr':
         estimator = LogisticRegression()
     elif estimator == 'svc':
@@ -1664,7 +1665,7 @@ def output_code_classifier_step(trial):
     Classifier
         The OutputCodeClassifier object step.
     """
-    estimator = trial.suggest_categorical('estimator', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
+    estimator = trial.suggest_categorical('estimator_output_code_classifier', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
     if estimator == 'lr':
         estimator = LogisticRegression()
     elif estimator == 'svc':
@@ -1694,7 +1695,7 @@ def multi_output_classifier_step(trial):
     Classifier
         The MultiOutputClassifier object step.
     """
-    estimator = trial.suggest_categorical('estimator', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
+    estimator = trial.suggest_categorical('estimator_multi_output_classifier', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
     if estimator == 'lr':
         estimator = LogisticRegression()
     elif estimator == 'svc':
@@ -1723,7 +1724,7 @@ def classifier_chain_step(trial):
     Classifier
         The ClassifierChain object step.
     """
-    estimator = trial.suggest_categorical('estimator', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
+    estimator = trial.suggest_categorical('estimator_classifier_chain', ['lr', 'svc', 'rfr', 'gbr', 'mlpr'])
     if estimator == 'lr':
         estimator = LogisticRegression()
     elif estimator == 'svc':
@@ -1734,7 +1735,7 @@ def classifier_chain_step(trial):
         estimator = GradientBoostingClassifier()
     else:
         estimator = MLPClassifier()
-    order = trial.suggest_categorical('order', ['random', 'count', 'prior'])
+    order = trial.suggest_categorical('order_classifier_chain', ['random', None])
     classifier_chain_kwargs = {'estimator': estimator, 'order': order}
     return classifier_chain_model(classifier_chain_kwargs=classifier_chain_kwargs)
 
@@ -1753,7 +1754,7 @@ def multi_output_regressor_step(trial):
     Regressor
         The MultiOutputRegressor object step.
     """
-    estimator = trial.suggest_categorical('estimator', ['lr', 'svr', 'rfr', 'gbr', 'mlpr'])
+    estimator = trial.suggest_categorical('estimator_multi_output_regressor', ['lr', 'svr', 'rfr', 'gbr', 'mlpr'])
     if estimator == 'lr':
         estimator = LinearRegression()
     elif estimator == 'svr':
@@ -1782,7 +1783,7 @@ def regressor_chain_step(trial):
     Regressor
         The RegressorChain object step.
     """
-    estimator = trial.suggest_categorical('estimator', ['lr', 'svr', 'rfr', 'gbr', 'mlpr'])
+    estimator = trial.suggest_categorical('estimator_regressor_chain', ['lr', 'svr', 'rfr', 'gbr', 'mlpr'])
     if estimator == 'lr':
         estimator = LinearRegression()
     elif estimator == 'svr':
@@ -1793,7 +1794,7 @@ def regressor_chain_step(trial):
         estimator = GradientBoostingRegressor()
     else:
         estimator = MLPRegressor()
-    order = trial.suggest_categorical('order', ['random', 'count', 'prior'])
+    order = trial.suggest_categorical('order_regressor_chain', ['random', 'count', 'prior'])
     regressor_chain_kwargs = {'estimator': estimator, 'order': order}
     return regressor_chain_model(regressor_chain_kwargs=regressor_chain_kwargs)
 
@@ -1830,10 +1831,10 @@ def mlp_regressor_step(trial):
     Regressor
         The MLPRegressor object step.
     """
-    hidden_layer_sizes = trial.suggest_categorical("hidden_layer_sizes",
+    hidden_layer_sizes = trial.suggest_categorical("hidden_layer_sizes_mlp_regressor",
                                                    [str(cat) for cat in [(50,), (100,), (50, 50), (100, 50)]])
-    activation = trial.suggest_categorical("activation", ["relu", "tanh"])
-    alpha = trial.suggest_loguniform("alpha", 1e-5, 1e-2)
+    activation = trial.suggest_categorical("activation_mlp_regressor", ["relu", "tanh"])
+    alpha = trial.suggest_loguniform("alpha_mlp_regressor", 1e-5, 1e-2)
     mlp_regressor_kwargs = {'hidden_layer_sizes': eval(hidden_layer_sizes), 'activation': activation, 'alpha': alpha}
     return mlp_regressor_model(mlp_regressor_kwargs=mlp_regressor_kwargs)
 
@@ -1852,10 +1853,10 @@ def mlp_classifier_step(trial):
     Classifier
         The MLPClassifier object step.
     """
-    hidden_layer_sizes = trial.suggest_categorical("hidden_layer_sizes",
+    hidden_layer_sizes = trial.suggest_categorical("hidden_layer_sizes_mlp_classifier",
                                                    [str(cat) for cat in [(50,), (100,), (50, 50), (100, 50)]])
-    activation = trial.suggest_categorical("activation", ["relu", "tanh"])
-    alpha = trial.suggest_loguniform("alpha", 1e-5, 1e-2)
+    activation = trial.suggest_categorical("activation_mlp_classifier", ["relu", "tanh"])
+    alpha = trial.suggest_loguniform("alpha_mlp_classifier", 1e-5, 1e-2)
     mlp_classifier_kwargs = {'hidden_layer_sizes': eval(hidden_layer_sizes), 'activation': activation, 'alpha': alpha}
     return mlp_classifier_model(mlp_classifier_kwargs=mlp_classifier_kwargs)
 
@@ -1874,7 +1875,7 @@ def label_propagation_step(trial):
     Classifier
         The LabelPropagation object step.
     """
-    kernel = trial.suggest_categorical("kernel", ["knn", "rbf"])
+    kernel = trial.suggest_categorical("kernel_label_propagation", ["knn", "rbf"])
     label_propagation_kwargs = {'kernel': kernel}
     return label_propagation_model(label_propagation_kwargs=label_propagation_kwargs)
 
@@ -1893,7 +1894,7 @@ def label_spreading_step(trial):
     Classifier
         The LabelSpreading object step.
     """
-    kernel = trial.suggest_categorical("kernel", ["knn", "rbf"])
+    kernel = trial.suggest_categorical("kernel_label_spreading", ["knn", "rbf"])
     label_spreading_kwargs = {'kernel': kernel}
     return label_spreading_model(label_spreading_kwargs=label_spreading_kwargs)
 

--- a/src/deepmol/pipeline_optimization/_standardizer_objectives.py
+++ b/src/deepmol/pipeline_optimization/_standardizer_objectives.py
@@ -9,7 +9,7 @@ _STANDARDIZERS = {"basic_standardizer": BasicStandardizer,
                   'pass_through_standardizer': PassThroughTransformer}
 
 
-def _get_standardizer(trial) -> Transformer:
+def _get_standardizer(trial, featurizer=None) -> Transformer:
     """
     Get a Standardizer object for the Optuna optimization.
 
@@ -30,6 +30,9 @@ def _get_standardizer(trial) -> Transformer:
             params = simple_standardisation
         else:
             params = heavy_standardisation
+            if featurizer is not None:
+                if featurizer.__class__.__name__ == "TwoDimensionDescriptors":
+                    params['ADD_HYDROGEN'] = False
         return CustomStandardizer(params)
     else:
         return _STANDARDIZERS[standardizer]()

--- a/src/deepmol/pipeline_optimization/_utils.py
+++ b/src/deepmol/pipeline_optimization/_utils.py
@@ -15,6 +15,7 @@ from deepmol.pipeline_optimization._scaler_objectives import _get_scaler
 from deepmol.pipeline_optimization._sklearn_model_objectives import _get_sk_model
 from deepmol.pipeline_optimization._standardizer_objectives import _get_standardizer
 from deepmol.pipeline_optimization._deepchem_models_objectives import *
+from deepmol.scalers.sklearn_scalers import MinMaxScaler
 
 
 def _get_preset(preset: Literal['deepchem', 'sklearn', 'keras', 'all']) -> callable:
@@ -155,11 +156,19 @@ def preset_deepchem_models(trial, data: Dataset) -> list:
     n_tasks = data.n_tasks
     mode = data.mode
     n_classes = len(set(data.y)) if mode == 'classification' else 1
+    if isinstance(mode, list):
+        if mode[0] == "classification":
+            n_classes = len(set(data.y[0]))
+        else:
+            n_classes = 1
     final_steps = [('standardizer', _get_standardizer(trial))]
     models = ["gat_model", "gcn_model", "attentive_fp_model", "pagtn_model", "chem_ception_model", "dag_model",
               "graph_conv_model", "smiles_to_vec_model", "text_cnn_model", "weave_model", "dmpnn_model"]
+    batch_size = trial.suggest_categorical("batch_size_deepchem", [8, 16, 32, 64, 128, 256, 512])
+    epochs=trial.suggest_int("epochs_deepchem", 100, 1000)
+    deepchem_kwargs = {"epochs": epochs}
     if mode == 'classification' or (len(set(mode)) == 1 and mode[0] == 'classification'):
-        models.extend(["multitask_classifier_model"])  # , "multitask_irv_classifier_model",
+        models.extend(["multitask_classifier_model", "robust_multitask_classifier_model"])  # , "multitask_irv_classifier_model",
         # "progressive_multitask_classifier_model", "robust_multitask_classifier_model", "sc_score_model"])
         if n_classes > 2:
             models.remove("text_cnn_model")
@@ -170,37 +179,47 @@ def preset_deepchem_models(trial, data: Dataset) -> list:
         mode = 'regression'
     else:
         raise ValueError("data mode must be either 'classification' or 'regression' or a list of both")
+    
     model_steps = trial.suggest_categorical("model_steps", models)
+
     if model_steps == "gat_model":
-        gat_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_gat = gat_model_steps(trial=trial, gat_kwargs=gat_kwargs)
+        gat_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_gat = gat_model_steps(trial=trial, gat_kwargs=gat_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_gat)
+
     elif model_steps == "gcn_model":
-        gcn_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_gcn = gcn_model_steps(trial=trial, gcn_kwargs=gcn_kwargs)
+        gcn_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_gcn = gcn_model_steps(trial=trial, gcn_kwargs=gcn_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_gcn)
+
     elif model_steps == "attentive_fp_model":
-        attentive_fp_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_attentive = attentive_fp_model_steps(trial=trial, attentive_fp_kwargs=attentive_fp_kwargs)
+        attentive_fp_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_attentive = attentive_fp_model_steps(trial=trial, attentive_fp_kwargs=attentive_fp_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_attentive)
+
     elif model_steps == "pagtn_model":
-        patgn_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_patgn = pagtn_model_steps(trial=trial, pagtn_kwargs=patgn_kwargs)
+        patgn_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_patgn = pagtn_model_steps(trial=trial, pagtn_kwargs=patgn_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_patgn)
+
     elif model_steps == "mpnn_model":
-        mpnn_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_mpnn = mpnn_model_steps(trial=trial, mpnn_kwargs=mpnn_kwargs)
+        mpnn_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_mpnn = mpnn_model_steps(trial=trial, mpnn_kwargs=mpnn_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_mpnn)
+
     elif model_steps == "megnet_model":
-        megnet_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_megnet = megnet_model_steps(trial=trial, megnet_kwargs=megnet_kwargs)
+        megnet_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_megnet = megnet_model_steps(trial=trial, megnet_kwargs=megnet_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_megnet)
+
     elif model_steps == "cnn_model":
         featurizer_scaler_model = _cnn_model_steps(trial, n_tasks, n_classes)
         final_steps.extend(featurizer_scaler_model)
+
     elif model_steps == "multitask_classifier_model":
         featurizer_scaler_model = _multitask_classifier_model_steps(trial, n_tasks, n_classes)
         final_steps.extend(featurizer_scaler_model)
+
     elif model_steps == "multitask_irv_classifier_model":
         featurizer = _get_featurizer(trial, '1D')
         multitask_irv_classifier_kwargs = {'n_tasks': n_tasks, 'n_classes': n_classes}
@@ -208,22 +227,26 @@ def preset_deepchem_models(trial, data: Dataset) -> list:
                                                           multitask_irv_classifier_kwargs=multitask_irv_classifier_kwargs)
         featurizer = ('featurizer', featurizer)
         final_steps.extend([featurizer, model_step[0]])
+
     elif model_steps == "progressive_multitask_classifier_model":
         featurizer = _get_featurizer(trial, '1D')
         n_features = len(featurizer.feature_names)
-        progressive_multitask_classifier_kwargs = {'n_tasks': n_tasks, 'n_features': n_features, 'n_classes': n_classes}
+        progressive_multitask_classifier_kwargs = {'n_tasks': n_tasks, 'n_features': n_features, 'n_classes': n_classes, 'batch_size': batch_size}
         model_step = progressive_multitask_classifier_model_steps(trial=trial,
-                                                                  progressive_multitask_classifier_kwargs=progressive_multitask_classifier_kwargs)
+                                                                  progressive_multitask_classifier_kwargs=progressive_multitask_classifier_kwargs,
+                                                                  deepchem_kwargs=deepchem_kwargs)
         featurizer = ('featurizer', featurizer)
         final_steps.extend([featurizer, model_step[0]])
     elif model_steps == "robust_multitask_classifier_model":
         featurizer = _get_featurizer(trial, '1D')
         n_features = len(featurizer.feature_names)
-        robust_multitask_classifier_kwargs = {'n_tasks': n_tasks, 'n_features': n_features, 'n_classes': n_classes}
+        robust_multitask_classifier_kwargs = {'n_tasks': n_tasks, 'n_features': n_features, 'n_classes': n_classes, 'batch_size': batch_size}
         model_step = robust_multitask_classifier_model_steps(trial=trial,
-                                                             robust_multitask_classifier_kwargs=robust_multitask_classifier_kwargs)
+                                                             robust_multitask_classifier_kwargs=robust_multitask_classifier_kwargs,
+                                                             deepchem_kwargs=deepchem_kwargs)
         featurizer = ('featurizer', featurizer)
         final_steps.extend([featurizer, model_step[0]])
+
     elif model_steps == "sc_score_model":
         featurizer = _get_featurizer(trial, '1D')
         n_features = len(featurizer.feature_names)
@@ -231,29 +254,34 @@ def preset_deepchem_models(trial, data: Dataset) -> list:
         model_step = sc_score_model_steps(trial=trial, sc_score_kwargs=sc_score_kwargs)
         featurizer = ('featurizer', featurizer)
         final_steps.extend([featurizer, model_step[0]])
+
     elif model_steps == "chem_ception_model":
-        chem_ception_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_chem_ception = chem_ception_model_steps(trial=trial, chem_ception_kwargs=chem_ception_kwargs)
+        chem_ception_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_chem_ception = chem_ception_model_steps(trial=trial, chem_ception_kwargs=chem_ception_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_chem_ception)
+
     elif model_steps == "dag_model":
-        dag_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_dag = dag_model_steps(trial=trial, dag_kwargs=dag_kwargs)
+        dag_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_dag = dag_model_steps(trial=trial, dag_kwargs=dag_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_dag)
+
     elif model_steps == "graph_conv_model":
-        graph_conv_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_graph_conv = graph_conv_model_steps(trial=trial, graph_conv_kwargs=graph_conv_kwargs)
+        graph_conv_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_graph_conv = graph_conv_model_steps(trial=trial, graph_conv_kwargs=graph_conv_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_graph_conv)
+
     elif model_steps == "smiles_to_vec_model":
-        smiles_to_vec_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
+        smiles_to_vec_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
         dataset_copy = deepcopy(data)
         ssf = SmilesSeqFeat()
         ssf.fit_transform(dataset_copy)
         chat_to_idx = ssf.char_to_idx
         smiles_to_vec_kwargs['char_to_idx'] = chat_to_idx
-        steps_smiles_to_vec = smiles_to_vec_model_steps(trial=trial, smiles_to_vec_kwargs=smiles_to_vec_kwargs)
+        steps_smiles_to_vec = smiles_to_vec_model_steps(trial=trial, smiles_to_vec_kwargs=smiles_to_vec_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_smiles_to_vec)
+
     elif model_steps == "text_cnn_model":
-        text_cnn_kwargs = {'n_tasks': n_tasks, 'mode': mode}
+        text_cnn_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'batch_size': batch_size}
         max_length = max([len(smile) for smile in data.smiles])
         padded_train_smiles = prepare_dataset_for_textcnn(data, max_length).ids
         fake_dataset = copy(data)
@@ -262,31 +290,39 @@ def preset_deepchem_models(trial, data: Dataset) -> list:
         text_cnn_kwargs['char_dict'] = char_dict
         text_cnn_kwargs['seq_length'] = seq_length
         padder = DatasetTransformer(prepare_dataset_for_textcnn, max_length=max_length)
-        final_steps.extend([('padder', padder), text_cnn_model_steps(trial=trial, text_cnn_kwargs=text_cnn_kwargs)[0]])
+        final_steps.extend([('padder', padder), text_cnn_model_steps(trial=trial, text_cnn_kwargs=text_cnn_kwargs, 
+                                                                     deepchem_kwargs=deepchem_kwargs)[0]])
+
     elif model_steps == "weave_model":
-        weave_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_weave = weave_model_steps(trial=trial, weave_kwargs=weave_kwargs)
+        weave_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_weave = weave_model_steps(trial=trial, weave_kwargs=weave_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_weave)
+
     elif model_steps == "dmpnn_model":
-        dmpnn_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes}
-        steps_dmpnn = dmpnn_model_steps(trial=trial, dmpnn_kwargs=dmpnn_kwargs)
+        dmpnn_kwargs = {'n_tasks': n_tasks, 'mode': mode, 'n_classes': n_classes, 'batch_size': batch_size}
+        steps_dmpnn = dmpnn_model_steps(trial=trial, dmpnn_kwargs=dmpnn_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(steps_dmpnn)
+
     elif model_steps == "progressive_multitask_regressor_model":
         featurizer_scaler_model_step = _progressive_multitask_regressor_model_steps(trial=trial, n_tasks=n_tasks)
         final_steps.extend(featurizer_scaler_model_step)
+
     elif model_steps == "robust_multitask_regressor_model":
         featurizer_scaler_model_step = _robust_multitask_regressor_model_steps(trial=trial, n_tasks=n_tasks)
         final_steps.extend(featurizer_scaler_model_step)
+
     elif model_steps == "dtnn_model":
         max_atoms = max([mol.GetNumAtoms() for mol in data.mols])
         featurizer = CoulombFeat(max_atoms=max_atoms)
-        dtnn_kwargs = {'n_tasks': n_tasks}
-        model_step = dtnn_model_steps(trial=trial, dtnn_kwargs=dtnn_kwargs)
+        dtnn_kwargs = {'n_tasks': n_tasks, 'batch_size': batch_size}
+        model_step = dtnn_model_steps(trial=trial, dtnn_kwargs=dtnn_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend([('featurizer', featurizer), model_step[0]])
+
     elif model_steps == "mat_model":
-        mat_kwargs = {}
-        mat_steps = mat_model_steps(trial=trial, mat_kwargs=mat_kwargs)
+        mat_kwargs = {"batch_size": batch_size}
+        mat_steps = mat_model_steps(trial=trial, mat_kwargs=mat_kwargs, deepchem_kwargs=deepchem_kwargs)
         final_steps.extend(mat_steps)
+
     elif model_steps == "multitask_regressor_model":
         featurizer_scaler_model_step = _multitask_regressor_model_steps(trial=trial, n_tasks=n_tasks)
         final_steps.extend(featurizer_scaler_model_step)
@@ -325,7 +361,14 @@ def preset_sklearn_models(trial, data: Dataset) -> list:
     else:
         sk_mode = mode
     sk_model = _get_sk_model(trial, task_type=sk_mode)
-    final_steps = [('standardizer', _get_standardizer(trial)), ('featurizer', featurizer), ('scaler', scaler),
+    if sk_model.model.__class__.__name__ == 'BernoulliNB' or sk_model.model.__class__.__name__ == 'MultinomialNB' or \
+            sk_model.model.__class__.__name__ == 'ComplementNB':
+        if featurizer.__class__.__name__ == 'TwoDimensionDescriptors' or \
+                featurizer.__class__.__name__ == 'All3DDescriptors' or \
+                    featurizer.__class__.__name__ == 'Mol2Vec':
+            scaler = MinMaxScaler()
+
+    final_steps = [('standardizer', _get_standardizer(trial, featurizer)), ('featurizer', featurizer), ('scaler', scaler),
                    ('feature_selector', feature_selector), ('model', sk_model)]
     return final_steps
 
@@ -340,6 +383,8 @@ def preset_keras_models(trial, data: Dataset) -> list:
         Optuna trial object.
     data: Dataset
         Dataset object.
+    validation_dataset: Dataset
+        Dataset object used for validation.
 
     Returns
     -------
@@ -364,7 +409,7 @@ def preset_keras_models(trial, data: Dataset) -> list:
         scaler = PassThroughTransformer()
         input_shape = featurizer.fit(data).shape
     keras_model = _get_keras_model(trial, input_shape, data)
-    final_steps = [('label_encoder', label_encoder), ('standardizer', _get_standardizer(trial)),
+    final_steps = [('label_encoder', label_encoder), ('standardizer', _get_standardizer(trial, featurizer)),
                    ('featurizer', featurizer), ('scaler', scaler), ('model', keras_model)]
     return final_steps
 

--- a/src/deepmol/pipeline_optimization/_utils.py
+++ b/src/deepmol/pipeline_optimization/_utils.py
@@ -168,15 +168,19 @@ def preset_deepchem_models(trial, data: Dataset) -> list:
     epochs=trial.suggest_int("epochs_deepchem", 100, 1000)
     deepchem_kwargs = {"epochs": epochs}
     if mode == 'classification' or (len(set(mode)) == 1 and mode[0] == 'classification'):
-        models.extend(["multitask_classifier_model", "robust_multitask_classifier_model"])  # , "multitask_irv_classifier_model",
+         # , "multitask_irv_classifier_model",
         # "progressive_multitask_classifier_model", "robust_multitask_classifier_model", "sc_score_model"])
         if n_classes > 2:
             models.remove("text_cnn_model")
+        if (len(set(mode)) == 1 and mode[0] == 'classification'):
+            models.extend(["multitask_classifier_model", "robust_multitask_classifier_model"]) 
         mode = 'classification'
     elif mode == 'regression' or (len(set(mode)) == 1 and mode[0] == 'regression'):
-        models.extend(["dtnn_model", "mat_model", "multitask_regressor_model"])  # ,
+        models.extend(["dtnn_model", "mat_model"])  # ,
         # "progressive_multitask_regressor_model", "robust_multitask_regressor_model"])
         mode = 'regression'
+        if (len(set(mode)) == 1 and mode[0] == 'regression'):
+            models.extend(["multitask_regressor_model"])
     else:
         raise ValueError("data mode must be either 'classification' or 'regression' or a list of both")
     

--- a/src/deepmol/pipeline_optimization/objective_wrapper.py
+++ b/src/deepmol/pipeline_optimization/objective_wrapper.py
@@ -97,8 +97,13 @@ class ObjectiveTrainEval(Objective):
             trial_id = str(trial.number)
             path = os.path.join(self.save_dir, f'trial_{trial_id}')
             pipeline = Pipeline(steps=self.objective_steps(trial, **self.kwargs), path=path)
-            pipeline.fit(train_dataset)
+            if pipeline.steps[-1][1].__class__.__name__ == 'KerasModel':
+                pipeline.fit(train_dataset, validation_dataset=test_dataset)
+            else:
+                pipeline.fit(train_dataset)
             score = pipeline.evaluate(test_dataset, [self.metric])[0][self.metric.name]
+            if score is None:
+                score = float('-inf') if self.direction == 'maximize' else float('inf')
 
             best_scores = self.study.user_attrs['best_scores']
             min_score = min(best_scores.values()) if len(best_scores) > 0 else float('inf')
@@ -114,11 +119,13 @@ class ObjectiveTrainEval(Objective):
                     if self.direction == 'maximize':
                         min_score_id = min(best_scores, key=best_scores.get)
                         del best_scores[min_score_id]
-                        shutil.rmtree(os.path.join(self.save_dir, f'trial_{min_score_id}'))
+                        if os.path.exists(os.path.join(self.save_dir, f'trial_{min_score_id}')):
+                            shutil.rmtree(os.path.join(self.save_dir, f'trial_{min_score_id}'))
                     else:
                         max_score_id = max(best_scores, key=best_scores.get)
                         del best_scores[max_score_id]
-                        shutil.rmtree(os.path.join(self.save_dir, f'trial_{max_score_id}'))
+                        if os.path.exists(os.path.join(self.save_dir, f'trial_{max_score_id}')):
+                            shutil.rmtree(os.path.join(self.save_dir, f'trial_{max_score_id}'))
 
             self.study.set_user_attr('best_scores', best_scores)
             return score

--- a/src/deepmol/pipeline_optimization/objective_wrapper.py
+++ b/src/deepmol/pipeline_optimization/objective_wrapper.py
@@ -89,51 +89,51 @@ class ObjectiveTrainEval(Objective):
         trial : optuna.trial.Trial
             Trial object that stores the hyperparameters.
         """
-        # try:
-        @timeout_decorator.timeout(self.trial_timeout, timeout_exception=optuna.TrialPruned)
-        def run_with_timeout():
-            train_dataset = copy(self.train_dataset)
-            test_dataset = copy(self.test_dataset)
-            trial_id = str(trial.number)
-            path = os.path.join(self.save_dir, f'trial_{trial_id}')
-            pipeline = Pipeline(steps=self.objective_steps(trial, **self.kwargs), path=path)
-            if pipeline.steps[-1][1].__class__.__name__ == 'KerasModel':
-                pipeline.fit(train_dataset, validation_dataset=test_dataset)
-            else:
-                pipeline.fit(train_dataset)
-            score = pipeline.evaluate(test_dataset, [self.metric])[0][self.metric.name]
-            if score is None:
-                score = float('-inf') if self.direction == 'maximize' else float('inf')
+        try:
+            @timeout_decorator.timeout(self.trial_timeout, timeout_exception=optuna.TrialPruned)
+            def run_with_timeout():
+                train_dataset = copy(self.train_dataset)
+                test_dataset = copy(self.test_dataset)
+                trial_id = str(trial.number)
+                path = os.path.join(self.save_dir, f'trial_{trial_id}')
+                pipeline = Pipeline(steps=self.objective_steps(trial, **self.kwargs), path=path)
+                if pipeline.steps[-1][1].__class__.__name__ == 'KerasModel':
+                    pipeline.fit(train_dataset, validation_dataset=test_dataset)
+                else:
+                    pipeline.fit(train_dataset)
+                score = pipeline.evaluate(test_dataset, [self.metric])[0][self.metric.name]
+                if score is None:
+                    score = float('-inf') if self.direction == 'maximize' else float('inf')
 
-            best_scores = self.study.user_attrs['best_scores']
-            min_score = min(best_scores.values()) if len(best_scores) > 0 else float('inf')
-            max_score = max(best_scores.values()) if len(best_scores) > 0 else float('-inf')
-            update_score = (self.direction == 'maximize' and score > min_score) or (
-                    self.direction == 'minimize' and score < max_score)
+                best_scores = self.study.user_attrs['best_scores']
+                min_score = min(best_scores.values()) if len(best_scores) > 0 else float('inf')
+                max_score = max(best_scores.values()) if len(best_scores) > 0 else float('-inf')
+                update_score = (self.direction == 'maximize' and score > min_score) or (
+                        self.direction == 'minimize' and score < max_score)
 
-            if len(best_scores) < self.save_top_n or update_score:
-                pipeline.save()
-                best_scores.update({trial_id: score})
+                if len(best_scores) < self.save_top_n or update_score:
+                    pipeline.save()
+                    best_scores.update({trial_id: score})
 
-                if len(best_scores) > self.save_top_n:
-                    if self.direction == 'maximize':
-                        min_score_id = min(best_scores, key=best_scores.get)
-                        del best_scores[min_score_id]
-                        if os.path.exists(os.path.join(self.save_dir, f'trial_{min_score_id}')):
-                            shutil.rmtree(os.path.join(self.save_dir, f'trial_{min_score_id}'))
-                    else:
-                        max_score_id = max(best_scores, key=best_scores.get)
-                        del best_scores[max_score_id]
-                        if os.path.exists(os.path.join(self.save_dir, f'trial_{max_score_id}')):
-                            shutil.rmtree(os.path.join(self.save_dir, f'trial_{max_score_id}'))
+                    if len(best_scores) > self.save_top_n:
+                        if self.direction == 'maximize':
+                            min_score_id = min(best_scores, key=best_scores.get)
+                            del best_scores[min_score_id]
+                            if os.path.exists(os.path.join(self.save_dir, f'trial_{min_score_id}')):
+                                shutil.rmtree(os.path.join(self.save_dir, f'trial_{min_score_id}'))
+                        else:
+                            max_score_id = max(best_scores, key=best_scores.get)
+                            del best_scores[max_score_id]
+                            if os.path.exists(os.path.join(self.save_dir, f'trial_{max_score_id}')):
+                                shutil.rmtree(os.path.join(self.save_dir, f'trial_{max_score_id}'))
 
-            self.study.set_user_attr('best_scores', best_scores)
-            return score
+                self.study.set_user_attr('best_scores', best_scores)
+                return score
 
-        return run_with_timeout()
-        # except ValueError as e:
-        #     print(e)
-        #     return float('inf') if self.direction == 'minimize' else float('-inf')
-        # except Exception as e:
-        #     print(e)
-        #     return float('inf') if self.direction == 'minimize' else float('-inf')
+            return run_with_timeout()
+        except ValueError as e:
+            print(e)
+            return float('inf') if self.direction == 'minimize' else float('-inf')
+        except Exception as e:
+            print(e)
+            return float('inf') if self.direction == 'minimize' else float('-inf')

--- a/tests/integration_tests/multitask/test_multitask_dataset.py
+++ b/tests/integration_tests/multitask/test_multitask_dataset.py
@@ -98,8 +98,8 @@ class TestMultitaskDataset(MultitaskBaseTestCase, TestCase):
         md._y = np.nan_to_num(md.y)
         ConvMolFeat().featurize(md, inplace=True)
         train, test = RandomSplitter().train_test_split(md, frac_train=0.8, seed=123)
-        graph = GraphConvModel(n_tasks=md.n_tasks)
-        model_graph = DeepChemModel(graph)
+        graph = GraphConvModel
+        model_graph = DeepChemModel(graph, n_tasks=md.n_tasks)
         model_graph.fit(train)
         test_preds = model_graph.predict(test)
         self.assertEqual(len(test_preds), len(test))

--- a/tests/integration_tests/pipeline/test_ensemble_pipeline.py
+++ b/tests/integration_tests/pipeline/test_ensemble_pipeline.py
@@ -152,14 +152,14 @@ class TestEnsemblePipeline(TestPipeline):
         self.assertEqual(len(predictions), len(self.dataset_descriptors.y))
 
     def test_deepchem_models(self):
-        from deepchem.models import GraphConvModel
+        from deepchem.models import AttentiveFPModel
         from deepmol.models import DeepChemModel
-        from deepmol.compound_featurization import ConvMolFeat
+        from deepmol.compound_featurization import MolGraphConvFeat
 
-        featurizer = ConvMolFeat()
-        graph_conv = GraphConvModel
-        deepchem_model = DeepChemModel(graph_conv, n_tasks=1, batch_size=50, mode='classification', model_dir='model_gc',
-                                       epochs=2)
+        featurizer = MolGraphConvFeat(use_edges=True)
+        graph_conv = AttentiveFPModel
+        deepchem_model = DeepChemModel(graph_conv, n_tasks=1, mode='classification', model_dir='model_gc',
+                                       epochs=2, device="cpu")
         pipeline1 = Pipeline(steps=[("featurizer", featurizer), ('model', deepchem_model)], path='test_pipeline_gc/')
         pipeline1.fit(self.dataset_descriptors)
         pipeline2 = Pipeline(steps=[("featurizer", featurizer), ('model', deepchem_model)], path='test_pipeline_gc2/')
@@ -170,5 +170,6 @@ class TestEnsemblePipeline(TestPipeline):
         pipeline1.save()
 
         voting_pipeline = VotingPipeline(pipelines=[pipeline1, pipeline2], weights=[1, 2])
-        voting_pipeline.save("test_voting_pipeline")
-        voting_pipeline_loaded = VotingPipeline.load("test_voting_pipeline")
+        voting_pipeline.predict_proba(self.dataset_descriptors)
+        # voting_pipeline.save("test_voting_pipeline")
+        # voting_pipeline_loaded = VotingPipeline.load("test_voting_pipeline")

--- a/tests/integration_tests/pipeline/test_ensemble_pipeline.py
+++ b/tests/integration_tests/pipeline/test_ensemble_pipeline.py
@@ -134,3 +134,19 @@ class TestEnsemblePipeline(TestPipeline):
 
         vp = VotingPipeline(pipelines=[pipeline1, pipeline3], weights=[1, 2])
         vp.predict(self.dataset_descriptors)
+
+
+    def test_predict_proba(self):
+        rf = RandomForestClassifier()
+        knn = KNeighborsClassifier()
+        fingerprint = MorganFingerprint()
+
+        model_rf = SklearnModel(model=rf, model_dir='model_rf')
+        model_knn = SklearnModel(model=knn, model_dir='model_knn')
+        pipeline1 = Pipeline(steps=[("fingerprint", fingerprint), ('model', model_rf)], path='test_pipeline_rf/')
+        pipeline3 = Pipeline(steps=[("fingerprint", fingerprint), ('model', model_knn)], path='test_pipeline_knn/')
+        vp = VotingPipeline(pipelines=[pipeline1, pipeline3], weights=[1, 2])
+        vp.fit(self.dataset_descriptors)
+        predictions = vp.predict_proba(self.dataset_descriptors)
+        print(predictions)
+        self.assertEqual(len(predictions), len(self.dataset_descriptors.y))

--- a/tests/integration_tests/pipeline/test_pipeline.py
+++ b/tests/integration_tests/pipeline/test_pipeline.py
@@ -243,9 +243,9 @@ class TestPipeline(TestCase):
         featurizer = ConvMolFeat()
 
         def graphconv_builder(graph_conv_layers, batch_size=256, epochs=5):
-            graph = GraphConvModel(n_tasks=1, graph_conv_layers=graph_conv_layers, batch_size=batch_size,
+            return DeepChemModel(GraphConvModel, model_dir=None, epochs=epochs,
+                                 n_tasks=1, graph_conv_layers=graph_conv_layers, batch_size=batch_size,
                                    mode='classification')
-            return DeepChemModel(graph, model_dir=None, epochs=epochs)
 
         steps = [('standardizer', standardizer),
                  ('featurizer', featurizer)]
@@ -274,9 +274,9 @@ class TestPipeline(TestCase):
         featurizer = ConvMolFeat()
 
         def graphconv_builder(graph_conv_layers, batch_size=256, epochs=5):
-            graph = GraphConvModel(n_tasks=1, graph_conv_layers=graph_conv_layers, batch_size=batch_size,
+            return DeepChemModel(GraphConvModel, model_dir=None, epochs=epochs,
+                                 n_tasks=1, graph_conv_layers=graph_conv_layers, batch_size=batch_size,
                                    mode='classification')
-            return DeepChemModel(graph, model_dir=None, epochs=epochs)
 
         steps = [('standardizer', standardizer),
                  ('featurizer', featurizer)]

--- a/tests/integration_tests/pipeline/test_pipeline.py
+++ b/tests/integration_tests/pipeline/test_pipeline.py
@@ -202,24 +202,22 @@ class TestPipeline(TestCase):
         self.assertTrue(np.array_equal(predictions, new_predictions))
 
     def test_hpo_cv_keras_models(self):
-        def basic_classification_model_builder(input_shape, layers):
+        def basic_classification_model_builder(input_dim, layers):
             model = Sequential()
-            model.add(Input(shape=input_shape))
+            model.add(Input(shape=input_dim))
             for layer in layers:
                 model.add(Dense(layer, activation='relu'))
             model.add(Dense(1, activation='sigmoid'))
             model.compile(loss='binary_crossentropy', optimizer='adam', metrics=['accuracy'])
             return model
 
-        keras_model = KerasModel(model_builder=basic_classification_model_builder, epochs=2, input_shape=(1024,))
         standardizer = BasicStandardizer()
         featurizer = MorganFingerprint(size=1024)
 
         steps = [('standardizer', standardizer),
-                 ('featurizer', featurizer),
-                 ('model', keras_model)]
+                 ('featurizer', featurizer)]
 
-        params_dict_keras = {"layers": [[512, 256], [512, 256, 128]], "input_shape": [(1024,)]}
+        params_dict_keras = {"layers": [[512, 256], [512, 256, 128]], "input_dim": [(1024,)]}
         optimizer = HyperparameterOptimizerCV(basic_classification_model_builder, metric=Metric(accuracy_score),
                                               maximize_metric=True,
                                               n_iter_search=2,
@@ -392,8 +390,8 @@ class TestPipeline(TestCase):
                                         unsupervised=None,
                                         model=keras_model)
 
-        deepchem_model = GraphConvModel(n_tasks=1, mode='classification')
-        model_graph = DeepChemModel(deepchem_model)
+        deepchem_model = GraphConvModel
+        model_graph = DeepChemModel(deepchem_model, n_tasks=1, mode='classification')
         self.validate_complete_pipeline(standardizer=ChEMBLStandardizer(),
                                         featurizer=ConvMolFeat(),
                                         scaler=PassThroughTransformer(),

--- a/tests/integration_tests/pipeline_optimization/test_pipeline_optimization.py
+++ b/tests/integration_tests/pipeline_optimization/test_pipeline_optimization.py
@@ -491,6 +491,7 @@ class TestPipelineOptimization(TestCase):
         self.assertEqual(po.best_params, po.best_trial.params)
         self.assertIsInstance(po.best_value, float)
 
+    @skip("This test takes too much time to run on CI")
     def test_deepchem_multi_task_model_steps(self):
         from deepmol.pipeline_optimization._utils import preset_deepchem_models
 
@@ -503,6 +504,7 @@ class TestPipelineOptimization(TestCase):
         self.assertEqual(po.best_params, po.best_trial.params)
         self.assertIsInstance(po.best_value, float)
 
+    @skip("This test takes too much time to run on CI")
     def test_deepchem_classification_model_steps(self):
         from deepmol.pipeline_optimization._utils import preset_deepchem_models
 
@@ -515,18 +517,44 @@ class TestPipelineOptimization(TestCase):
         self.assertEqual(po.best_params, po.best_trial.params)
         self.assertIsInstance(po.best_value, float)
 
+    @skip("This test takes too much time to run on CI")
     def test_deepchem_regression_model_steps(self):
         from deepmol.pipeline_optimization._utils import preset_deepchem_models
 
         study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        po = PipelineOptimization(direction='minimize', study_name=study_name)
         metric = Metric(mean_squared_error)
         train, test = RandomSplitter().train_test_split(self.dataset_regression, seed=123)
         po.optimize(train_dataset=train, test_dataset=test, objective_steps=preset_deepchem_models, metric=metric, n_trials=100,
                     save_top_n=3, data=train, trial_timeout=60*10)
         self.assertEqual(po.best_params, po.best_trial.params)
         self.assertIsInstance(po.best_value, float)
+    
+    @skip
+    def test_all_regression_model_steps(self):
 
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='minimize', study_name=study_name)
+        metric = Metric(mean_squared_error)
+        train, test = RandomSplitter().train_test_split(self.dataset_regression, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps="all", metric=metric, n_trials=100,
+                    save_top_n=3, data=train, trial_timeout=60*10)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip
+    def test_all_classification_model_steps(self):
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps="all", metric=metric, n_trials=100,
+                    save_top_n=3, data=train, trial_timeout=60*10)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip("This test takes too much time to run on CI")
     def test_gcn_featurization(self):
 
         from deepmol.standardizer import CustomStandardizer

--- a/tests/integration_tests/pipeline_optimization/test_pipeline_optimization.py
+++ b/tests/integration_tests/pipeline_optimization/test_pipeline_optimization.py
@@ -11,6 +11,7 @@ import optuna
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import accuracy_score, mean_squared_error, precision_score
 from sklearn.svm import SVC
+from deepmol.base.transformer import DatasetTransformer
 
 from deepmol.loaders import CSVLoader
 from deepmol.metrics import Metric
@@ -153,13 +154,212 @@ class TestPipelineOptimization(TestCase):
         self.assertEqual(new_predictions, po.best_value)
 
     @skip("This test is too slow to run on CI and can have different results on different trials")
+    def test_predictor_gat(self):
+        from deepmol.pipeline_optimization._deepchem_models_objectives import gat_model_steps
+
+        def objective(trial):
+            gat_kwargs = {'n_tasks': 1, 'mode': "classification", 'n_classes': 2}
+            steps = gat_model_steps(trial, gat_kwargs=gat_kwargs)
+            return steps
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps=objective, metric=metric, n_trials=5,
+                    save_top_n=3)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip("This test is too slow to run on CI and can have different results on different trials")
+    def test_predictor_gcn(self):
+        from deepmol.pipeline_optimization._deepchem_models_objectives import gcn_model_steps
+
+        def objective(trial):
+            gcn_kwargs = {'n_tasks': 1, 'mode': "classification", 'n_classes': 2}
+            steps = gcn_model_steps(trial, gcn_kwargs=gcn_kwargs)
+            return steps
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps=objective, metric=metric, n_trials=5,
+                    save_top_n=3)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip("This test is too slow to run on CI and can have different results on different trials")
+    def test_predictor_attentive_fp(self):
+        from deepmol.pipeline_optimization._deepchem_models_objectives import attentive_fp_model_steps
+
+        def objective(trial):
+            attentivefp_kwargs = {'n_tasks': 1, 'mode': "classification", 'n_classes': 2}
+            steps = attentive_fp_model_steps(trial, attentive_fp_kwargs=attentivefp_kwargs)
+            return steps
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps=objective, metric=metric, n_trials=5,
+                    save_top_n=3)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip("This test is too slow to run on CI and can have different results on different trials")
+    def test_predictor_pagtn_model_steps(self):
+        from deepmol.pipeline_optimization._deepchem_models_objectives import pagtn_model_steps
+
+        def objective(trial):
+            pagtn_model_kwargs = {'n_tasks': 1, 'mode': "classification", 'n_classes': 2}
+            steps = pagtn_model_steps(trial, pagtn_kwargs=pagtn_model_kwargs)
+            return steps
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps=objective, metric=metric, n_trials=5,
+                    save_top_n=3)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip("This test is too slow to run on CI and can have different results on different trials")
+    def test_predictor_dag_model_steps(self):
+        from deepmol.pipeline_optimization._deepchem_models_objectives import dag_model_steps
+
+        def objective(trial):
+            dag_kwargs = {'n_tasks': 1, 'mode': "classification", 'n_classes': 2}
+            steps = dag_model_steps(trial, dag_kwargs=dag_kwargs)
+            return steps
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps=objective, metric=metric, n_trials=5,
+                    save_top_n=3)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip("This test is too slow to run on CI and can have different results on different trials")
+    def test_predictor_graph_conv_model_steps(self):
+        from deepmol.pipeline_optimization._deepchem_models_objectives import graph_conv_model_steps
+
+        def objective(trial):
+            graph_conv_kwargs = {'n_tasks': 1, 'mode': "classification", 'n_classes': 2}
+            steps = graph_conv_model_steps(trial, graph_conv_kwargs=graph_conv_kwargs)
+            return steps
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps=objective, metric=metric, n_trials=5,
+                    save_top_n=3)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip("This test is too slow to run on CI and can have different results on different trials")
+    def test_predictor_smiles_to_vec_model_steps(self):
+        from deepmol.pipeline_optimization._deepchem_models_objectives import smiles_to_vec_model_steps
+        from deepmol.compound_featurization import SmilesSeqFeat
+
+        def objective(trial):
+            smiles_to_vec_kwargs = {'n_tasks': 1, 'mode': "classification", 'n_classes': 2}
+            ssf = SmilesSeqFeat()
+            ssf.fit_transform(self.dataset_descriptors)
+            chat_to_idx = ssf.char_to_idx
+            smiles_to_vec_kwargs['char_to_idx'] = chat_to_idx
+            steps = smiles_to_vec_model_steps(trial, smiles_to_vec_kwargs=smiles_to_vec_kwargs)
+            return steps
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps=objective, metric=metric, n_trials=5,
+                    save_top_n=3)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip("This test is too slow to run on CI")
+    def test_predictor_text_cnn_model_steps(self):
+        from deepmol.pipeline_optimization._deepchem_models_objectives import text_cnn_model_steps
+        from deepmol.pipeline_optimization._utils import prepare_dataset_for_textcnn
+        from deepchem.models import TextCNNModel
+        
+        def objective(trial):
+            text_cnn_kwargs = {'n_tasks': 1, 'mode': "classification", 'n_classes': 2}
+            max_length = max([len(smile) for smile in self.dataset_descriptors.smiles])
+            padded_train_smiles = prepare_dataset_for_textcnn(self.dataset_descriptors, max_length).ids
+            fake_dataset = copy(self.dataset_descriptors)
+            fake_dataset._ids = padded_train_smiles
+            char_dict, seq_length = TextCNNModel.build_char_dict(fake_dataset)
+            text_cnn_kwargs['char_dict'] = char_dict
+            text_cnn_kwargs['seq_length'] = seq_length
+            padder = DatasetTransformer(prepare_dataset_for_textcnn, max_length=max_length)
+            steps = []
+            steps.extend([('padder', padder), text_cnn_model_steps(trial=trial, text_cnn_kwargs=text_cnn_kwargs)[0]])
+            return steps
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps=objective, metric=metric, n_trials=5,
+                    save_top_n=3)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    def test_predictor_weave_model_steps(self):
+        from deepmol.pipeline_optimization._deepchem_models_objectives import weave_model_steps
+
+        def objective(trial):
+            weave_kwargs = {'n_tasks': 1, 'mode': "classification", 'n_classes': 2}
+            steps = weave_model_steps(trial, weave_kwargs=weave_kwargs)
+            return steps
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps=objective, metric=metric, n_trials=5,
+                    save_top_n=3)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip("This test is too slow to run on CI")
+    def test_predictor_dtnn_model_steps(self):
+        from deepmol.pipeline_optimization._deepchem_models_objectives import dtnn_model_steps
+        from deepmol.compound_featurization import CoulombFeat
+
+        def objective(trial):
+            max_atoms = max([mol.GetNumAtoms() for mol in self.dataset_descriptors.mols])
+            featurizer = CoulombFeat(max_atoms=max_atoms)
+            dtnn_kwargs = {'n_tasks': 1}
+            model_step = dtnn_model_steps(trial=trial, dtnn_kwargs=dtnn_kwargs)
+            final_steps = [('featurizer', featurizer), model_step[0]]
+            return final_steps
+
+        study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        po = PipelineOptimization(direction='maximize', study_name=study_name)
+        metric = Metric(accuracy_score)
+        train, test = RandomSplitter().train_test_split(self.dataset_descriptors, seed=123)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps=objective, metric=metric, n_trials=5,
+                    save_top_n=3)
+        self.assertEqual(po.best_params, po.best_trial.params)
+        self.assertIsInstance(po.best_value, float)
+
+    @skip("This test is too slow to run on CI and can have different results on different trials")
     def test_classification_preset(self):
         storage_name = "sqlite:///test_pipeline.db"
         study_name = f"test_predictor_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
         po = PipelineOptimization(direction='maximize', study_name=study_name, storage=storage_name)
         metric = Metric(accuracy_score)
         train, test = RandomSplitter().train_test_split(self.dataset_smiles, seed=123)
-        po.optimize(train_dataset=train, test_dataset=test, objective_steps='keras', metric=metric, n_trials=3,
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps='deepchem', metric=metric, n_trials=3,
                     data=train, save_top_n=2)
         self.assertEqual(po.best_params, po.best_trial.params)
         self.assertIsInstance(po.best_value, float)
@@ -185,8 +385,8 @@ class TestPipelineOptimization(TestCase):
         po = PipelineOptimization(direction='maximize', study_name=study_name, storage=storage_name)
         metric = Metric(accuracy_score)
         train, test = RandomSplitter().train_test_split(self.dataset_multiclass, seed=123)
-        po.optimize(train_dataset=train, test_dataset=test, objective_steps='all', metric=metric, n_trials=3,
-                    data=train, save_top_n=2, trial_timeout=10)
+        po.optimize(train_dataset=train, test_dataset=test, objective_steps='deepchem', metric=metric, n_trials=3,
+                    data=train, save_top_n=2, trial_timeout=10*60)
         self.assertEqual(po.best_params, po.best_trial.params)
         self.assertIsInstance(po.best_value, float)
 

--- a/tests/unit_tests/hyperparameter_optimisation/test_deep_chem_hyperparameter_optimization.py
+++ b/tests/unit_tests/hyperparameter_optimisation/test_deep_chem_hyperparameter_optimization.py
@@ -33,9 +33,8 @@ class TestDeepChemHyperparameterOptimization(ModelsTestCase, TestCase):
         ds_test.X = ConvMolFeaturizer().featurize([MolFromSmiles('CCC')] * 10)
 
         def graphconv_builder(graph_conv_layers, batch_size=256, epochs=5):
-            graph = GraphConvModel(n_tasks=1, graph_conv_layers=graph_conv_layers, batch_size=batch_size,
-                                   mode='classification')
-            return DeepChemModel(graph, model_dir=None, epochs=epochs)
+            return DeepChemModel(GraphConvModel, n_tasks=1, graph_conv_layers=graph_conv_layers, batch_size=batch_size,
+                                   mode='classification', epochs=epochs)
 
         model_graph = HyperparameterOptimizerCV(model_builder=graphconv_builder,
                                                 metric=Metric(roc_auc_score),
@@ -67,9 +66,8 @@ class TestDeepChemHyperparameterOptimization(ModelsTestCase, TestCase):
         from deepmol.parameter_optimization import HyperparameterOptimizerValidation
 
         def graphconv_builder(graph_conv_layers, batch_size=256, epochs=5):
-            graph = GraphConvModel(n_tasks=1, graph_conv_layers=graph_conv_layers, batch_size=batch_size,
+            return DeepChemModel(GraphConvModel, epochs=epochs, n_tasks=1, graph_conv_layers=graph_conv_layers, batch_size=batch_size,
                                    mode='classification')
-            return DeepChemModel(graph, epochs=epochs)
 
         model_graph = HyperparameterOptimizerValidation(model_builder=graphconv_builder,
                                                         metric=Metric(accuracy_score),

--- a/tests/unit_tests/hyperparameter_optimisation/test_keras_hyperparameter_optimization.py
+++ b/tests/unit_tests/hyperparameter_optimisation/test_keras_hyperparameter_optimization.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from sklearn.metrics import accuracy_score
 
 from deepmol.metrics import Metric
-from deepmol.parameter_optimization import HyperparameterOptimizerValidation
+from deepmol.parameter_optimization import HyperparameterOptimizerValidation, HyperparameterOptimizerCV
 from unit_tests.models.test_models import ModelsTestCase
 from tensorflow.keras.layers import Dropout
 from tensorflow import keras
@@ -51,3 +51,18 @@ class TestKerasHyperparameterOptimization(ModelsTestCase, TestCase):
 
         best_dnn, best_hyperparams, all_results = optimizer.fit(train_dataset=self.binary_dataset,
                                                                 valid_dataset=self.binary_dataset)
+        
+    def test_fit_predict_evaluate_cv(self):
+        params_dict_dense = {
+            "input_dim": [self.binary_dataset.X.shape[1]],
+            "dropout": [0.5, 0.6, 0.7],
+            "optimizer": ['adam']
+        }
+        optimizer = HyperparameterOptimizerCV(create_model, metric=Metric(accuracy_score),
+                                                      maximize_metric=True,
+                                                    n_iter_search=2,
+                                                    cv=3,
+                                                    params_dict=params_dict_dense,
+                                                    model_type="keras", epochs=2)
+
+        best_dnn, best_hyperparams, all_results = optimizer.fit(train_dataset=self.binary_dataset)

--- a/tests/unit_tests/models/test_deepchem_model.py
+++ b/tests/unit_tests/models/test_deepchem_model.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 from deepchem.feat import ConvMolFeaturizer, MolGraphConvFeaturizer
-from deepchem.models import GraphConvModel, TextCNNModel, GCNModel
+from deepchem.models import GraphConvModel, TextCNNModel, GCNModel, MultitaskClassifier
 from deepchem.models.layers import DTNNEmbedding, Highway
 from rdkit.Chem import MolFromSmiles
 from sklearn.metrics import f1_score
@@ -15,6 +15,7 @@ from deepmol.metrics.metrics_functions import roc_auc_score, precision_score, ac
 from deepmol.metrics import Metric
 from deepmol.models import DeepChemModel
 from deepmol.splitters import RandomSplitter
+from deepmol.compound_featurization import MorganFingerprint
 from unit_tests.models.test_models import ModelsTestCase
 
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
@@ -186,3 +187,9 @@ class TestDeepChemModel(ModelsTestCase, TestCase):
         model = DeepChemModel.load("test_model")
         model.predict(self.binary_dataset)
         self.assertTrue(os.path.exists("test_model"))
+
+    def test_multitask_regressors_and_classifiers(self):
+        ds_train = self.multitask_dataset
+
+        model = DeepChemModel(MultitaskClassifier, n_tasks=ds_train.n_tasks, n_features=ds_train.X.shape[1])
+        self.assertEqual(model.model.model.mode, "classification")

--- a/tests/unit_tests/models/test_keras_model.py
+++ b/tests/unit_tests/models/test_keras_model.py
@@ -134,8 +134,6 @@ class TestKerasModel(ModelsTestCase, TestCase):
             shutil.rmtree("test_model")
             self.assertEqual(2, len(model.history['loss']))
             self.assertEqual(2, len(model.history['val_loss']))
-            
-
 
     def test_weights_reset(self):
         model = keras_fcnn_model(model_kwargs={'input_dim': 50}, keras_kwargs={})

--- a/tests/unit_tests/models/test_keras_model.py
+++ b/tests/unit_tests/models/test_keras_model.py
@@ -88,7 +88,7 @@ class TestKerasModel(ModelsTestCase, TestCase):
         model.save("test_model")
         loaded_model = KerasModel.load("test_model")
         self.assertEqual(2, loaded_model.epochs)
-        self.assertEqual(50, loaded_model.model.sk_params["input_dim"])
+        self.assertEqual(50, loaded_model.parameters_to_save["input_dim"])
         loaded_model_predictions = loaded_model.predict(self.binary_dataset_test)
 
         assert np.array_equal(first_predictions, loaded_model_predictions)
@@ -107,7 +107,7 @@ class TestKerasModel(ModelsTestCase, TestCase):
 
             model.save("test_model")
             loaded_model = KerasModel.load("test_model")
-            self.assertEqual(50, loaded_model.model.sk_params["input_dim"])
+            self.assertEqual(50, loaded_model.parameters_to_save["input_dim"])
             loaded_model_predictions = loaded_model.predict(self.binary_dataset_test)
             assert np.array_equal(first_predictions, loaded_model_predictions)
 
@@ -116,9 +116,9 @@ class TestKerasModel(ModelsTestCase, TestCase):
     def test_weights_reset(self):
         model = keras_fcnn_model(model_kwargs={'input_dim': 50}, keras_kwargs={})
         model.fit(self.binary_dataset)
-        last_loss = model.history.history['loss'][-1]
+        last_loss = model.history['loss'][-1]
         model.fit(self.binary_dataset)
-        self.assertGreater(model.history.history['loss'][0], last_loss)
+        self.assertGreater(model.history['loss'][0], last_loss)
 
     @skip("This test is too slow for CI")
     def test_rnn_baseline_models(self):

--- a/tests/unit_tests/models/test_keras_model.py
+++ b/tests/unit_tests/models/test_keras_model.py
@@ -16,7 +16,7 @@ from tensorflow.keras.layers import Dense, Dropout, GaussianNoise, Conv1D, Flatt
 from tensorflow.keras.optimizers import Adadelta, Adam, RMSprop
 from keras.callbacks import EarlyStopping
 
-
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 
 def make_cnn_model(input_dim=None,

--- a/tests/unit_tests/models/test_models.py
+++ b/tests/unit_tests/models/test_models.py
@@ -80,6 +80,7 @@ class ModelsTestCase(ABC):
 
         # create multitask classification dataset
         self.multitask_dataset = SmilesDatasetMagicMock(spec=SmilesDataset,
+                                                        mols=mols,
                                                         X=x,
                                                         y=y_multitask,
                                                         ids=ids,
@@ -88,7 +89,9 @@ class ModelsTestCase(ABC):
                                                                      'multitask_label_3'],
                                                         mode=["classification"] * 3)
         self.multitask_dataset.__len__.return_value = 100
+        # self.multiclass_dataset.mols.return_value = mols
         self.multitask_dataset_test = SmilesDatasetMagicMock(spec=SmilesDataset,
+                                                             mols=mols,
                                                              X=x_test,
                                                              y=y_multitask_test,
                                                              ids=ids_test,


### PR DESCRIPTION
This PR makes DeepMol compatible with tensorflow version 2.13 onwards. Moreover, it fixes some issues in the pipeline optimization process and adds new features.

Starting with the compatibility issue:

In Tensorflow version 2.13.0, KerasClassifier and KerasRegressor were deprecated (refer to [this release note](https://github.com/tensorflow/tensorflow/releases/tag/v2.13.0)). So, DeepMol started using scikeras instead of the wrappers from tensorflow, as they advised in the release note. 
This broke the way we were saving deepchem models, and for that reason, I changed the DeepMol API for deepchem models from this:

```python
graph = GraphConvModel(n_tasks=ds_train.n_tasks, mode='classification')
model_graph = DeepChemModel(graph)

model_graph.fit(ds_train)
```

to 

```python
graph = GraphConvModel
model_graph = DeepChemModel(graph, n_tasks=ds_train.n_tasks, mode='classification')

model_graph.fit(ds_train)
```

So, now deepchem models are not instantiated by the user, and the parameters for the model constructor are passed to the **DeepChem** model class constructor. This way, we can know agnostically which parameters are required to pass to the model's class constructor and pass them when restoring the model is needed. 

I tried to find issues that led to failed trials in the pipeline optimization process and solved most of them. Models that use DGL are now available if GPU is not. Moreover, I added a way of optimizing the batch size and epochs and added an early stopping to the keras models. 

Finally, tensorflow 2.14 does not support python 3.8, then, when released, this version of deepmol no longer support python 3.8. 